### PR TITLE
feat: add llama.cpp/GGUF provider via llama-server OpenAI-compatible API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,4 @@ jobs:
       - run: npm run build
 
       - run: npm test
+        shell: bash

--- a/docs/superpowers/specs/2026-04-04-llamacpp-gguf-design.md
+++ b/docs/superpowers/specs/2026-04-04-llamacpp-gguf-design.md
@@ -1,0 +1,50 @@
+# llama.cpp / GGUF Support Design
+
+## Problem
+Users with .gguf model files cannot use them in openHarness without installing Ollama. The config.yaml format for local models is also unclear.
+
+## Solution
+Add a `llamacpp` provider that speaks to `llama-server` via OpenAI-compatible API. This is the industry-standard approach used by Claude Code, OpenCode, Aider, and Cline in 2026.
+
+## Architecture
+- New `LlamaCppProvider` class in `src/providers/llamacpp.ts`
+- Registered in `src/providers/index.ts` alongside existing providers
+- Default baseUrl: `http://localhost:8080` (llama-server default)
+- Config: uses existing `provider`, `model`, `baseUrl` fields — no schema changes
+
+## Provider API
+| Method | Endpoint | Notes |
+|---|---|---|
+| stream() | POST /v1/chat/completions | SSE streaming |
+| complete() | POST /v1/chat/completions | stream: false |
+| fetchModels() | GET /v1/models | Lists loaded models |
+| healthCheck() | GET /v1/models | Returns true if 200 |
+
+## UX
+- Init wizard: new "llama.cpp / GGUF" entry with collapsible setup instructions
+- Setup panel shows: `llama-server --model ./your-model.gguf --port 8080 --alias my-model`
+- Connection failure shows same instructions (not generic error)
+- `oh models` command: queries fetchModels() and pretty-prints
+
+## Config Example
+```yaml
+provider: llamacpp
+# Model alias — must match --alias passed to llama-server
+model: my-model
+# URL where llama-server is running
+baseUrl: http://localhost:8080
+permissionMode: ask
+```
+
+## User Setup Flow
+1. Download a GGUF model (e.g. from Hugging Face)
+2. Run: `llama-server --model ./model.gguf --port 8080 --alias my-model`
+3. Run: `oh init` → select "llama.cpp / GGUF" → test connection → pick model
+4. Start: `oh` or `oh --model llamacpp/my-model`
+
+## Verification
+1. llama-server running → oh init detects it, lists models
+2. oh models → shows available models
+3. oh --model llamacpp/my-model → streaming chat works
+4. llama-server stopped → oh init shows setup instructions
+5. npm run build → no TypeScript errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhijiewang/openharness",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhijiewang/openharness",
-      "version": "0.1.0",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@types/marked": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "prepare": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit",
     "start": "node dist/main.js"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "prepare": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "tsx --test \"src/**/*.test.ts\"",
+    "test": "tsx --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "start": "node dist/main.js"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "tsc",
     "prepare": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "node scripts/test.mjs",
     "typecheck": "tsc --noEmit",
     "start": "node dist/main.js"
   },

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,0 +1,21 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+function findTests(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...findTests(full));
+    } else if (entry.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const tests = findTests("src");
+execSync(`tsx --test ${tests.map((f) => `"${f}"`).join(" ")}`, {
+  stdio: "inherit",
+});

--- a/src/components/InitWizard.tsx
+++ b/src/components/InitWizard.tsx
@@ -32,6 +32,7 @@ const PROVIDERS: Provider[] = [
   { key: "openai",     label: "OpenAI",                    defaultModel: "gpt-4o",           needsApiKey: true  },
   { key: "anthropic",  label: "Anthropic (Claude)",        defaultModel: "claude-sonnet-4-6",needsApiKey: true  },
   { key: "openrouter", label: "OpenRouter",                defaultModel: "openai/gpt-4o",    needsApiKey: true,  defaultBaseUrl: "https://openrouter.ai/api/v1" },
+  { key: "llamacpp",   label: "llama.cpp / GGUF (local, no Ollama needed)", defaultModel: "", needsApiKey: false, defaultBaseUrl: "http://localhost:8080" },
   { key: "custom",     label: "Custom (OpenAI-compatible)",defaultModel: "",                 needsApiKey: true  },
 ];
 
@@ -215,11 +216,31 @@ export default function InitWizard({ onDone }: Props) {
         </Box>
       )}
 
+      {step === "testing" && provider.key === "llamacpp" && (
+        <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1} marginBottom={1}>
+          <Text color="cyan">llama.cpp setup</Text>
+          <Text dimColor>To use llama.cpp, start llama-server first:</Text>
+          <Text dimColor>  llama-server --model ./your-model.gguf --port 8080 --alias my-model</Text>
+          <Text dimColor>Then enter "my-model" as the model name below.</Text>
+        </Box>
+      )}
+
       {step === "testing" && (
         <Box flexDirection="column">
           {testStatus === "testing" && <Text color="yellow">⟳ Testing connection to {provider.label}...</Text>}
           {testStatus === "ok"      && <Text color="green">✓ Connected!</Text>}
-          {testStatus === "fail"    && <Text color="red">✗ Failed: <Text dimColor>{testError}</Text></Text>}
+          {testStatus === "fail" && provider.key !== "llamacpp" && (
+            <Text color="red">✗ Failed: <Text dimColor>{testError}</Text></Text>
+          )}
+          {testStatus === "fail" && provider.key === "llamacpp" && (
+            <Box flexDirection="column" borderStyle="single" borderColor="red" paddingX={1} marginTop={1}>
+              <Text color="red">✗ Could not connect to llama-server.</Text>
+              <Text dimColor>{testError}</Text>
+              <Text> </Text>
+              <Text color="yellow">Make sure llama-server is running:</Text>
+              <Text dimColor>  llama-server --model ./your-model.gguf --port 8080 --alias my-model</Text>
+            </Box>
+          )}
         </Box>
       )}
 

--- a/src/components/InitWizard.tsx
+++ b/src/components/InitWizard.tsx
@@ -216,7 +216,7 @@ export default function InitWizard({ onDone }: Props) {
         </Box>
       )}
 
-      {step === "testing" && provider.key === "llamacpp" && (
+      {step === "testing" && provider.key === "llamacpp" && testStatus !== "ok" && (
         <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1} marginBottom={1}>
           <Text color="cyan">llama.cpp setup</Text>
           <Text dimColor>To use llama.cpp, start llama-server first:</Text>

--- a/src/harness/config.test.ts
+++ b/src/harness/config.test.ts
@@ -54,6 +54,37 @@ test("writeOhConfig() preserves optional fields", () => {
   assert.equal(cfg.mcpServers?.[0]?.name, "fs");
 });
 
+test("writeOhConfig() llamacpp roundtrip", () => {
+  const dir = tmp();
+  writeOhConfig({
+    provider: "llamacpp",
+    model: "llama3-local",
+    permissionMode: "ask",
+    baseUrl: "http://localhost:8080",
+  }, dir);
+  const cfg = readOhConfig(dir);
+  assert.ok(cfg !== null);
+  assert.equal(cfg.provider, "llamacpp");
+  assert.equal(cfg.model, "llama3-local");
+  assert.equal(cfg.permissionMode, "ask");
+  assert.equal(cfg.baseUrl, "http://localhost:8080");
+});
+
+test("writeOhConfig() llamacpp model with colon roundtrips correctly", () => {
+  const dir = tmp();
+  writeOhConfig({
+    provider: "llamacpp",
+    model: "my:model",
+    permissionMode: "trust",
+    apiKey: "secret#key",
+  }, dir);
+  const cfg = readOhConfig(dir);
+  assert.ok(cfg !== null);
+  assert.equal(cfg.model, "my:model");
+  assert.equal(cfg.apiKey, "secret#key");
+  assert.equal(cfg.permissionMode, "trust");
+});
+
 test("writeOhConfig() overwrites existing config", () => {
   const dir = tmp();
   writeOhConfig({ provider: "openai", model: "gpt-4o", permissionMode: "ask" }, dir);

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -55,6 +55,7 @@ export function writeOhConfig(cfg: OhConfig, root?: string): void {
       `model: ${yamlScalar(cfg.model || "")}`,
       "",
       "# URL where llama-server is running (default port: 8080)",
+      "# Note: do not include /v1 — it is added automatically",
       `baseUrl: ${yamlScalar(cfg.baseUrl || "http://localhost:8080")}`,
       "",
       `permissionMode: ${yamlScalar(cfg.permissionMode)}`,

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -40,5 +40,29 @@ export function readOhConfig(root?: string): OhConfig | null {
 export function writeOhConfig(cfg: OhConfig, root?: string): void {
   const p = configPath(root);
   mkdirSync(join(root ?? ".", ".oh"), { recursive: true });
+
+  if (cfg.provider === "llamacpp") {
+    const lines = [
+      "# openHarness configuration",
+      `provider: llamacpp`,
+      "",
+      "# Model alias — must match --alias passed to llama-server",
+      "# Example: llama-server --model ./llama3.gguf --port 8080 --alias llama3-local",
+      `model: ${cfg.model || ""}`,
+      "",
+      "# URL where llama-server is running (default port: 8080)",
+      `baseUrl: ${cfg.baseUrl || "http://localhost:8080"}`,
+      "",
+      `permissionMode: ${cfg.permissionMode}`,
+    ];
+    if (cfg.apiKey) lines.push(`apiKey: ${cfg.apiKey}`);
+    if (cfg.mcpServers?.length) {
+      // fall back to stringify for mcpServers since it's complex
+      lines.push("", stringify({ mcpServers: cfg.mcpServers }).trim());
+    }
+    writeFileSync(p, lines.join("\n") + "\n");
+    return;
+  }
+
   writeFileSync(p, stringify(cfg));
 }

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -23,6 +23,10 @@ export type OhConfig = {
   mcpServers?: McpServerConfig[];
 };
 
+function yamlScalar(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 function configPath(root?: string): string {
   return join(root ?? ".", ".oh", "config.yaml");
 }
@@ -48,14 +52,14 @@ export function writeOhConfig(cfg: OhConfig, root?: string): void {
       "",
       "# Model alias — must match --alias passed to llama-server",
       "# Example: llama-server --model ./llama3.gguf --port 8080 --alias llama3-local",
-      `model: ${cfg.model || ""}`,
+      `model: ${yamlScalar(cfg.model || "")}`,
       "",
       "# URL where llama-server is running (default port: 8080)",
-      `baseUrl: ${cfg.baseUrl || "http://localhost:8080"}`,
+      `baseUrl: ${yamlScalar(cfg.baseUrl || "http://localhost:8080")}`,
       "",
-      `permissionMode: ${cfg.permissionMode}`,
+      `permissionMode: ${yamlScalar(cfg.permissionMode)}`,
     ];
-    if (cfg.apiKey) lines.push(`apiKey: ${cfg.apiKey}`);
+    if (cfg.apiKey) lines.push(`apiKey: ${yamlScalar(cfg.apiKey)}`);
     if (cfg.mcpServers?.length) {
       // fall back to stringify for mcpServers since it's complex
       lines.push("", stringify({ mcpServers: cfg.mcpServers }).trim());

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -216,30 +216,65 @@ program
 // ── models ──
 program
   .command("models")
-  .description("List available models and pricing")
+  .description("List available models from configured provider")
   .action(async () => {
-    console.log();
-    console.log("  Model                         Provider     Input/1M    Output/1M");
-    console.log("  " + "─".repeat(65));
+    const { createProvider } = await import("./providers/index.js");
+    const config = readOhConfig();
 
-    // Try listing Ollama local models
+    if (!config) {
+      console.log();
+      console.log("  No config found, defaulting to Ollama");
+      console.log();
+      console.log(`  Provider: ollama`);
+      console.log("  " + "─".repeat(43));
+      try {
+        const { provider } = await createProvider("ollama/llama3");
+        const models = "fetchModels" in provider && typeof (provider as any).fetchModels === "function"
+          ? await (provider as any).fetchModels()
+          : provider.listModels();
+        if (models.length === 0) {
+          console.log("  No models found. Make sure llama-server is running.");
+        } else {
+          for (const m of models) {
+            const ctx = (m as any).contextWindow ? `  ctx:${(m as any).contextWindow}` : "";
+            const tools = (m as any).supportsTools !== undefined ? `  tools:${(m as any).supportsTools ? "yes" : "no"}` : "";
+            console.log(`  ${m.id.padEnd(20)}${ctx}${tools}`);
+          }
+        }
+      } catch {
+        console.log("  No models found. Make sure llama-server is running.");
+      }
+      console.log();
+      return;
+    }
+
+    const providerLabel = config.baseUrl
+      ? `${config.provider} (${config.baseUrl})`
+      : config.provider;
+    console.log();
+    console.log(`  Provider: ${providerLabel}`);
+    console.log("  " + "─".repeat(43));
+
     try {
-      const { createProvider } = await import("./providers/index.js");
-      const { provider } = await createProvider("ollama/llama3");
-      const ollamaModels = "fetchModels" in provider && typeof (provider as any).fetchModels === "function"
+      const modelId = `${config.provider}/${config.model}`;
+      const overrides: Record<string, string> = {};
+      if (config.baseUrl) overrides.baseUrl = config.baseUrl;
+      if (config.apiKey) overrides.apiKey = config.apiKey;
+      const { provider } = await createProvider(modelId, overrides);
+      const models = "fetchModels" in provider && typeof (provider as any).fetchModels === "function"
         ? await (provider as any).fetchModels()
         : provider.listModels();
-      for (const m of ollamaModels) {
-        console.log(`  ${m.id.padEnd(30)} ${"ollama".padEnd(12)} free`);
+      if (models.length === 0) {
+        console.log("  No models found. Make sure llama-server is running.");
+      } else {
+        for (const m of models) {
+          const ctx = (m as any).contextWindow ? `  ctx:${(m as any).contextWindow}` : "";
+          const tools = (m as any).supportsTools !== undefined ? `  tools:${(m as any).supportsTools ? "yes" : "no"}` : "";
+          console.log(`  ${m.id.padEnd(20)}${ctx}${tools}`);
+        }
       }
-    } catch { /* Ollama not running */ }
-
-    // Cloud models from pricing registry
-    for (const [model, [inp, out]] of Object.entries(MODEL_PRICING).sort()) {
-      if (inp === 0) continue;
-      console.log(
-        `  ${model.padEnd(30)} ${guessProvider(model).padEnd(12)} $${inp.toFixed(2).padStart(6)}    $${out.toFixed(2).padStart(6)}`,
-      );
+    } catch {
+      console.log("  No models found. Make sure llama-server is running.");
     }
     console.log();
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -225,7 +225,7 @@ program
       console.log();
       console.log("  No config found, defaulting to Ollama");
       console.log();
-      console.log(`  Provider: ollama`);
+      console.log(`  Provider: ollama (http://localhost:11434)`);
       console.log("  " + "─".repeat(43));
       try {
         const { provider } = await createProvider("ollama/llama3");
@@ -233,7 +233,7 @@ program
           ? await (provider as any).fetchModels()
           : provider.listModels();
         if (models.length === 0) {
-          console.log("  No models found. Make sure llama-server is running.");
+          console.log("  No models found. Make sure Ollama is running: ollama serve");
         } else {
           for (const m of models) {
             const ctx = (m as any).contextWindow ? `  ctx:${(m as any).contextWindow}` : "";
@@ -242,7 +242,7 @@ program
           }
         }
       } catch {
-        console.log("  No models found. Make sure llama-server is running.");
+        console.log("  No models found. Make sure Ollama is running: ollama serve");
       }
       console.log();
       return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { PermissionMode } from "./types/permissions.js";
-import type { Provider } from "./providers/base.js";
+import type { Provider, ProviderConfig } from "./providers/base.js";
 
 const VERSION = "0.4.0";
 
@@ -91,9 +91,12 @@ program
 
     const { createProvider } = await import("./providers/index.js");
     const effectiveModel = (opts.model as string | undefined) ?? savedConfig?.model;
+    const overrides: Partial<ProviderConfig> = {};
+    if (savedConfig?.apiKey) overrides.apiKey = savedConfig.apiKey;
+    if (savedConfig?.baseUrl) overrides.baseUrl = savedConfig.baseUrl;
     const { provider, model } = await createProvider(
       effectiveModel,
-      savedConfig?.apiKey ? { apiKey: savedConfig.apiKey, baseUrl: savedConfig.baseUrl } : undefined,
+      Object.keys(overrides).length ? overrides : undefined,
     );
     const { query } = await import("./query.js");
 
@@ -169,7 +172,10 @@ program
     let resolvedModel: string;
     try {
       const { createProvider } = await import("./providers/index.js");
-      const result = await createProvider(effectiveModel, savedConfig?.apiKey ? { apiKey: savedConfig.apiKey, baseUrl: savedConfig.baseUrl } : undefined);
+      const overrides: Partial<ProviderConfig> = {};
+      if (savedConfig?.apiKey) overrides.apiKey = savedConfig.apiKey;
+      if (savedConfig?.baseUrl) overrides.baseUrl = savedConfig.baseUrl;
+      const result = await createProvider(effectiveModel, Object.keys(overrides).length ? overrides : undefined);
       provider = result.provider;
       resolvedModel = result.model;
     } catch (err) {
@@ -411,11 +417,3 @@ program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(err instanceof Error ? err.message : String(err));
   process.exitCode = 1;
 });
-
-function guessProvider(model: string): string {
-  if (model.includes("gpt") || model.startsWith("o3")) return "openai";
-  if (model.includes("claude")) return "anthropic";
-  if (model.includes("deepseek")) return "deepseek";
-  if (model.includes("qwen")) return "qwen";
-  return "unknown";
-}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,6 +7,7 @@ import { OllamaProvider } from "./ollama.js";
 import { OpenAIProvider } from "./openai.js";
 import { AnthropicProvider } from "./anthropic.js";
 import { OpenRouterProvider } from "./openrouter.js";
+import { LlamaCppProvider } from "./llamacpp.js";
 
 /**
  * Create a provider from a model string like "ollama/llama3" or "gpt-4o".
@@ -52,6 +53,8 @@ function createProviderInstance(name: string, config: ProviderConfig): Provider 
       return new AnthropicProvider(config);
     case "openrouter":
       return new OpenRouterProvider(config);
+    case "llamacpp":
+      return new LlamaCppProvider(config);
     default:
       // Treat as OpenAI-compatible
       return new OpenAIProvider({ ...config, baseUrl: config.baseUrl ?? `https://api.${name}.com/v1` });

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -54,6 +54,7 @@ function createProviderInstance(name: string, config: ProviderConfig): Provider 
     case "openrouter":
       return new OpenRouterProvider(config);
     case "llamacpp":
+    case "llama.cpp":
       return new LlamaCppProvider(config);
     default:
       // Treat as OpenAI-compatible

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -13,7 +13,9 @@ export class LlamaCppProvider implements Provider {
   private defaultModel: string;
 
   constructor(config: ProviderConfig) {
-    this.baseUrl = (config.baseUrl ?? "http://localhost:8080").replace(/\/$/, "");
+    this.baseUrl = (config.baseUrl ?? "http://localhost:8080")
+      .replace(/\/$/, "")
+      .replace(/\/v1$/, "");
     this.defaultModel = config.defaultModel ?? "";
   }
 

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -104,7 +104,10 @@ export class LlamaCppProvider implements Provider {
     }
 
     const reader = res.body?.getReader();
-    if (!reader) return;
+    if (!reader) {
+      yield { type: "error", message: "LlamaCpp: response body is not readable" };
+      return;
+    }
 
     const decoder = new TextDecoder();
     let buffer = "";
@@ -164,8 +167,9 @@ export class LlamaCppProvider implements Provider {
             } else {
               // Continuation delta
               const acc = toolCallAccumulators.get(idx);
-              if (acc && tc.function?.arguments) {
-                acc.args += tc.function.arguments;
+              if (acc) {
+                if (tc.function?.name) acc.name += tc.function.name;
+                if (tc.function?.arguments) acc.args += tc.function.arguments;
               }
             }
           }

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -13,7 +13,7 @@ export class LlamaCppProvider implements Provider {
   private defaultModel: string;
 
   constructor(config: ProviderConfig) {
-    this.baseUrl = (config.baseUrl ?? "http://localhost:8080/v1").replace(/\/$/, "");
+    this.baseUrl = (config.baseUrl ?? "http://localhost:8080").replace(/\/$/, "");
     this.defaultModel = config.defaultModel ?? "";
   }
 
@@ -88,7 +88,7 @@ export class LlamaCppProvider implements Provider {
 
     let res: Response;
     try {
-      res = await fetch(`${this.baseUrl}/chat/completions`, {
+      res = await fetch(`${this.baseUrl}/v1/chat/completions`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -182,13 +182,6 @@ export class LlamaCppProvider implements Provider {
         arguments: safeParse(acc.args),
       } satisfies ToolCallComplete;
     }
-
-    // If no usage chunk was emitted, emit a zero cost_update so callers always get one
-    if (toolCallAccumulators.size === 0) {
-      // Only emit if we never got usage — llama-server may not send it
-      // We already emitted inside the loop if chunk.usage existed, so this is a no-op guard.
-      // (No action needed here; guard is implicit.)
-    }
   }
 
   async complete(
@@ -206,7 +199,7 @@ export class LlamaCppProvider implements Provider {
     const convertedTools = this.convertTools(tools);
     if (convertedTools) body.tools = convertedTools;
 
-    const res = await fetch(`${this.baseUrl}/chat/completions`, {
+    const res = await fetch(`${this.baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -238,7 +231,7 @@ export class LlamaCppProvider implements Provider {
 
   async fetchModels(): Promise<ModelInfo[]> {
     try {
-      const res = await fetch(`${this.baseUrl}/models`);
+      const res = await fetch(`${this.baseUrl}/v1/models`);
       if (!res.ok) return [];
       const data: any = await res.json();
       return (data.data ?? []).map((m: any) => ({
@@ -258,7 +251,7 @@ export class LlamaCppProvider implements Provider {
 
   async healthCheck(): Promise<boolean> {
     try {
-      const res = await fetch(`${this.baseUrl}/models`);
+      const res = await fetch(`${this.baseUrl}/v1/models`);
       return res.ok;
     } catch {
       return false;

--- a/src/providers/llamacpp.ts
+++ b/src/providers/llamacpp.ts
@@ -1,0 +1,273 @@
+/**
+ * LlamaCpp provider — local LLM inference via llama-server OpenAI-compatible REST API.
+ */
+
+import type { Message, ToolCall } from "../types/message.js";
+import type { StreamEvent, ToolCallComplete } from "../types/events.js";
+import { createAssistantMessage } from "../types/message.js";
+import type { Provider, APIToolDef, ModelInfo, ProviderConfig } from "./base.js";
+
+export class LlamaCppProvider implements Provider {
+  readonly name = "llamacpp";
+  private baseUrl: string;
+  private defaultModel: string;
+
+  constructor(config: ProviderConfig) {
+    this.baseUrl = (config.baseUrl ?? "http://localhost:8080/v1").replace(/\/$/, "");
+    this.defaultModel = config.defaultModel ?? "";
+  }
+
+  private convertMessages(
+    messages: Message[],
+    systemPrompt: string,
+  ): unknown[] {
+    const converted: unknown[] = [];
+    if (systemPrompt) {
+      converted.push({ role: "system", content: systemPrompt });
+    }
+    for (const msg of messages) {
+      if (msg.role === "system") continue;
+
+      if (msg.role === "assistant" && msg.toolCalls?.length) {
+        converted.push({
+          role: "assistant",
+          content: msg.content || "",
+          tool_calls: msg.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: "function",
+            function: {
+              name: tc.toolName,
+              arguments: JSON.stringify(tc.arguments),
+            },
+          })),
+        });
+      } else if (msg.role === "tool" && msg.toolResults?.length) {
+        for (const tr of msg.toolResults) {
+          converted.push({
+            role: "tool",
+            content: tr.output,
+            tool_call_id: tr.callId,
+          });
+        }
+      } else {
+        converted.push({
+          role: msg.role === "user" ? "user" : msg.role === "assistant" ? "assistant" : msg.role,
+          content: msg.content,
+        });
+      }
+    }
+    return converted;
+  }
+
+  private convertTools(tools?: APIToolDef[]): unknown[] | undefined {
+    if (!tools?.length) return undefined;
+    return tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.function.name,
+        description: t.function.description,
+        parameters: t.function.parameters,
+      },
+    }));
+  }
+
+  async *stream(
+    messages: Message[],
+    systemPrompt: string,
+    tools?: APIToolDef[],
+    model?: string,
+  ): AsyncGenerator<StreamEvent, void> {
+    const m = model ?? this.defaultModel;
+    const body: Record<string, unknown> = {
+      model: m,
+      messages: this.convertMessages(messages, systemPrompt),
+      stream: true,
+    };
+    const convertedTools = this.convertTools(tools);
+    if (convertedTools) body.tools = convertedTools;
+
+    let res: Response;
+    try {
+      res = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      yield { type: "error", message: `LlamaCpp request failed: ${err}` };
+      return;
+    }
+
+    if (!res.ok) {
+      yield { type: "error", message: `LlamaCpp HTTP ${res.status}: ${await res.text()}` };
+      return;
+    }
+
+    const reader = res.body?.getReader();
+    if (!reader) return;
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+    // Track tool call argument deltas by index
+    const toolCallAccumulators: Map<number, { id: string; name: string; args: string }> = new Map();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data:")) continue;
+        const payload = trimmed.slice(5).trim();
+        if (payload === "[DONE]") continue;
+
+        let chunk: any;
+        try {
+          chunk = JSON.parse(payload);
+        } catch {
+          continue;
+        }
+
+        // Usage info
+        if (chunk.usage) {
+          const inputTokens = chunk.usage.prompt_tokens ?? 0;
+          const outputTokens = chunk.usage.completion_tokens ?? 0;
+          yield { type: "cost_update", inputTokens, outputTokens, cost: 0, model: m };
+        }
+
+        const delta = chunk.choices?.[0]?.delta;
+        if (!delta) continue;
+
+        if (delta.content) {
+          yield { type: "text_delta", content: delta.content };
+        }
+
+        if (delta.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const idx = tc.index ?? 0;
+            if (tc.id) {
+              // New tool call starting
+              toolCallAccumulators.set(idx, {
+                id: tc.id,
+                name: tc.function?.name ?? "",
+                args: tc.function?.arguments ?? "",
+              });
+              yield {
+                type: "tool_call_start",
+                toolName: tc.function?.name ?? "unknown",
+                callId: tc.id,
+              };
+            } else {
+              // Continuation delta
+              const acc = toolCallAccumulators.get(idx);
+              if (acc && tc.function?.arguments) {
+                acc.args += tc.function.arguments;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Emit tool_call_complete for each accumulated tool call
+    for (const [, acc] of toolCallAccumulators) {
+      yield {
+        type: "tool_call_complete",
+        callId: acc.id,
+        toolName: acc.name,
+        arguments: safeParse(acc.args),
+      } satisfies ToolCallComplete;
+    }
+
+    // If no usage chunk was emitted, emit a zero cost_update so callers always get one
+    if (toolCallAccumulators.size === 0) {
+      // Only emit if we never got usage — llama-server may not send it
+      // We already emitted inside the loop if chunk.usage existed, so this is a no-op guard.
+      // (No action needed here; guard is implicit.)
+    }
+  }
+
+  async complete(
+    messages: Message[],
+    systemPrompt: string,
+    tools?: APIToolDef[],
+    model?: string,
+  ): Promise<Message> {
+    const m = model ?? this.defaultModel;
+    const body: Record<string, unknown> = {
+      model: m,
+      messages: this.convertMessages(messages, systemPrompt),
+      stream: false,
+    };
+    const convertedTools = this.convertTools(tools);
+    if (convertedTools) body.tools = convertedTools;
+
+    const res = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      throw new Error(`LlamaCpp HTTP ${res.status}: ${await res.text()}`);
+    }
+
+    const data: any = await res.json();
+    const choice = data.choices?.[0]?.message;
+    const content = choice?.content ?? "";
+    let toolCalls: ToolCall[] | undefined;
+
+    if (choice?.tool_calls?.length) {
+      toolCalls = choice.tool_calls.map((tc: any) => ({
+        id: tc.id ?? crypto.randomUUID(),
+        toolName: tc.function?.name ?? "unknown",
+        arguments: safeParse(tc.function?.arguments),
+      }));
+    }
+
+    return createAssistantMessage(content, toolCalls);
+  }
+
+  listModels(): ModelInfo[] {
+    return [];
+  }
+
+  async fetchModels(): Promise<ModelInfo[]> {
+    try {
+      const res = await fetch(`${this.baseUrl}/models`);
+      if (!res.ok) return [];
+      const data: any = await res.json();
+      return (data.data ?? []).map((m: any) => ({
+        id: m.id as string,
+        provider: "llamacpp",
+        contextWindow: 128_000,
+        supportsTools: true,
+        supportsStreaming: true,
+        supportsVision: false,
+        inputCostPerMtok: 0,
+        outputCostPerMtok: 0,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const res = await fetch(`${this.baseUrl}/models`);
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function safeParse(json: string | undefined): Record<string, unknown> {
+  if (!json) return {};
+  try { return JSON.parse(json); }
+  catch { return {}; }
+}

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -227,16 +227,27 @@ export class OllamaProvider implements Provider {
       const res = await fetch(`${this.baseUrl}/api/tags`);
       if (!res.ok) return [];
       const data: any = await res.json();
-      return (data.models ?? []).map((m: any) => ({
-        id: m.name as string,
-        provider: "ollama",
-        contextWindow: 128_000,
-        supportsTools: true,
-        supportsStreaming: true,
-        supportsVision: false,
-        inputCostPerMtok: 0,
-        outputCostPerMtok: 0,
-      }));
+      return (data.models ?? []).map((m: any) => {
+        // Detect vision support from model families
+        // Presence of "clip" or "llava" in families indicates vision capability
+        const families = m.details?.families ?? [];
+        const supportsVision = Array.isArray(families) &&
+          families.some((f: string) => f.includes("clip") || f.includes("llava"));
+
+        return {
+          id: m.name as string,
+          provider: "ollama",
+          // Default context window: Ollama's /api/tags doesn't expose context_window,
+          // so 128K is a reasonable default for modern LLMs
+          contextWindow: 128_000,
+          // Safe default: modern models typically support tools
+          supportsTools: true,
+          supportsStreaming: true,
+          supportsVision,
+          inputCostPerMtok: 0,
+          outputCostPerMtok: 0,
+        };
+      });
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary

- Adds `llamacpp` provider connecting to `llama-server` via its OpenAI-compatible REST API (`/v1/chat/completions`, `/v1/models`) — the industry-standard approach used by Claude Code, OpenCode, and Aider
- `oh init` now includes a **llama.cpp / GGUF** option with inline setup instructions and helpful error messages when the server isn't reachable
- `oh models` uses the configured provider (not hardcoded Ollama)
- `.oh/config.yaml` is written with inline comments for llamacpp configs, explaining each field
- Handles `provider: llama.cpp` alias and strips accidental `/v1` suffix from `baseUrl`
- Fixes hardcoded Ollama model metadata: vision support now detected from model families

Closes #5

## User Setup Flow

```bash
# 1. Download a GGUF model and start llama-server
llama-server --model ./qwen2.5-coder-7b.gguf --port 8080 --alias qwen-coder

# 2. Run oh init, select "llama.cpp / GGUF"
oh init

# 3. Start coding
oh
```

## Test Plan

- [x] `oh init` → select `llama.cpp / GGUF` → wizard detects server and lists models
- [x] `oh init` with llama-server stopped → shows setup instructions + llama-server command
- [x] `oh models` → lists models from configured provider
- [x] `oh --model llamacpp/my-model` → streaming chat works
- [x] Config `provider: llama.cpp` (with dot) is accepted as alias
- [x] Config `baseUrl: http://localhost:8080/v1` (with `/v1`) works correctly
- [x] `npm test` → 66/66 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)