### PR TITLE
feat: add LM Studio provider

### DIFF
--- a/src/components/InitWizard.tsx
+++ b/src/components/InitWizard.tsx
@@ -33,6 +33,7 @@ const PROVIDERS: Provider[] = [
   { key: "anthropic",  label: "Anthropic (Claude)",        defaultModel: "claude-sonnet-4-6",needsApiKey: true  },
   { key: "openrouter", label: "OpenRouter",                defaultModel: "openai/gpt-4o",    needsApiKey: true,  defaultBaseUrl: "https://openrouter.ai/api/v1" },
   { key: "llamacpp",   label: "llama.cpp / GGUF (local, no Ollama needed)", defaultModel: "", needsApiKey: false, defaultBaseUrl: "http://localhost:8080" },
+  { key: "lmstudio",   label: "LM Studio (local, OpenAI-compatible)",       defaultModel: "", needsApiKey: false, defaultBaseUrl: "http://localhost:1234" },
   { key: "custom",     label: "Custom (OpenAI-compatible)",defaultModel: "",                 needsApiKey: true  },
 ];
 
@@ -225,12 +226,30 @@ export default function InitWizard({ onDone }: Props) {
         </Box>
       )}
 
+      {step === "testing" && provider.key === "lmstudio" && testStatus !== "ok" && (
+        <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1} marginBottom={1}>
+          <Text color="cyan">LM Studio setup</Text>
+          <Text dimColor>Enable the local server in LM Studio:</Text>
+          <Text dimColor>  Settings → Local Server → Start Server (port 1234)</Text>
+          <Text dimColor>Then load a model and set the model name below.</Text>
+        </Box>
+      )}
+
       {step === "testing" && (
         <Box flexDirection="column">
           {testStatus === "testing" && <Text color="yellow">⟳ Testing connection to {provider.label}...</Text>}
           {testStatus === "ok"      && <Text color="green">✓ Connected!</Text>}
-          {testStatus === "fail" && provider.key !== "llamacpp" && (
+          {testStatus === "fail" && provider.key !== "llamacpp" && provider.key !== "lmstudio" && (
             <Text color="red">✗ Failed: <Text dimColor>{testError}</Text></Text>
+          )}
+          {testStatus === "fail" && provider.key === "lmstudio" && (
+            <Box flexDirection="column" borderStyle="single" borderColor="red" paddingX={1} marginTop={1}>
+              <Text color="red">✗ Could not connect to LM Studio.</Text>
+              <Text dimColor>{testError}</Text>
+              <Text> </Text>
+              <Text color="yellow">Make sure LM Studio local server is running:</Text>
+              <Text dimColor>  Settings → Local Server → Start Server (port 1234)</Text>
+            </Box>
           )}
           {testStatus === "fail" && provider.key === "llamacpp" && (
             <Box flexDirection="column" borderStyle="single" borderColor="red" paddingX={1} marginTop={1}>

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -45,18 +45,23 @@ export function writeOhConfig(cfg: OhConfig, root?: string): void {
   const p = configPath(root);
   mkdirSync(join(root ?? ".", ".oh"), { recursive: true });
 
-  if (cfg.provider === "llamacpp") {
+  if (cfg.provider === "llamacpp" || cfg.provider === "lmstudio") {
+    const isLmStudio = cfg.provider === "lmstudio";
     const lines = [
       "# openHarness configuration",
-      `provider: llamacpp`,
+      `provider: ${cfg.provider}`,
       "",
-      "# Model alias — must match --alias passed to llama-server",
-      "# Example: llama-server --model ./llama3.gguf --port 8080 --alias llama3-local",
+      isLmStudio
+        ? "# Model name — must match the model loaded in LM Studio"
+        : "# Model alias — must match --alias passed to llama-server",
+      ...(isLmStudio ? [] : ["# Example: llama-server --model ./llama3.gguf --port 8080 --alias llama3-local"]),
       `model: ${yamlScalar(cfg.model || "")}`,
       "",
-      "# URL where llama-server is running (default port: 8080)",
+      isLmStudio
+        ? "# URL where LM Studio local server is running (default port: 1234)"
+        : "# URL where llama-server is running (default port: 8080)",
       "# Note: do not include /v1 — it is added automatically",
-      `baseUrl: ${yamlScalar(cfg.baseUrl || "http://localhost:8080")}`,
+      `baseUrl: ${yamlScalar(cfg.baseUrl || (isLmStudio ? "http://localhost:1234" : "http://localhost:8080"))}`,
       "",
       `permissionMode: ${yamlScalar(cfg.permissionMode)}`,
     ];

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -56,6 +56,9 @@ function createProviderInstance(name: string, config: ProviderConfig): Provider 
     case "llamacpp":
     case "llama.cpp":
       return new LlamaCppProvider(config);
+    case "lmstudio":
+    case "lm studio":
+      return new LlamaCppProvider({ ...config, baseUrl: config.baseUrl ?? "http://localhost:1234" });
     default:
       // Treat as OpenAI-compatible
       return new OpenAIProvider({ ...config, baseUrl: config.baseUrl ?? `https://api.${name}.com/v1` });


### PR DESCRIPTION
## Summary

- Adds `lmstudio` provider reusing `LlamaCppProvider` — LM Studio exposes the same OpenAI-compatible API, just on port `1234`
- `oh init` includes a new **LM Studio** option with setup instructions specific to LM Studio's GUI ("Settings → Local Server → Start Server")
- Self-documenting `.oh/config.yaml` with LM Studio-specific comments
- Accepts `lm studio` (with space) as alias
- No new provider class needed — zero code duplication

## User setup

1. Open LM Studio → Settings → Local Server → Start Server (port 1234)
2. Load a model
3. Run `oh init` → select "LM Studio"

Or manually in `.oh/config.yaml`:
\`\`\`yaml
provider: lmstudio
model: my-model
baseUrl: http://localhost:1234
permissionMode: ask
\`\`\`

## Test plan
- [ ] `oh init` → select LM Studio → wizard detects server, lists models
- [ ] LM Studio stopped → shows setup instructions
- [ ] `oh --model lmstudio/my-model` → streaming chat works
- [ ] `provider: lm studio` alias accepted
- [ ] `npm test` → 66/66 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)