### PR TITLE
fix: surface stream errors instead of silent blank responses

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -124,7 +124,10 @@ export class AnthropicProvider implements Provider {
     }
 
     const reader = res.body?.getReader();
-    if (!reader) return;
+    if (!reader) {
+      yield { type: "error", message: "Anthropic: response body is not readable" };
+      return;
+    }
 
     const decoder = new TextDecoder();
     let buffer = "";

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -105,7 +105,10 @@ export class OllamaProvider implements Provider {
     }
 
     const reader = res.body?.getReader();
-    if (!reader) return;
+    if (!reader) {
+      yield { type: "error", message: "Ollama: response body is not readable" };
+      return;
+    }
 
     const decoder = new TextDecoder();
     let buffer = "";

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -107,7 +107,10 @@ export class OpenAIProvider implements Provider {
     }
 
     const reader = res.body?.getReader();
-    if (!reader) return;
+    if (!reader) {
+      yield { type: "error", message: "OpenAI: response body is not readable" };
+      return;
+    }
 
     const decoder = new TextDecoder();
     let buffer = "";

--- a/src/query.ts
+++ b/src/query.ts
@@ -221,6 +221,15 @@ export async function* query(
       return;
     }
 
+    // Guard against empty turns (e.g. unreadable body yielded an error event)
+    if (assistantContent === "" && toolCalls.length === 0) {
+      yield {
+        type: "error",
+        message: "No response received. Check that your model server is running and the model name is correct.",
+      };
+      return;
+    }
+
     // Add assistant message to history
     state.messages.push(
       createAssistantMessage(assistantContent, toolCalls.length > 0 ? toolCalls : undefined),


### PR DESCRIPTION
## Problem

When a model server is misconfigured or unreachable, users see a blank response — the spinner stops but nothing appears. No error message is shown.

Root cause: three providers (`ollama`, `openai`, `anthropic`) silently `return` when the response body is unreadable. Additionally, when a stream ends with zero content, an empty assistant message is added silently.

## Changes

**Providers — yield error instead of silent return:**
- `ollama.ts` → `"Ollama: response body is not readable"`
- `openai.ts` → `"OpenAI: response body is not readable"`
- `anthropic.ts` → `"Anthropic: response body is not readable"`
- `llamacpp.ts` was already correct (reference implementation)

**query.ts — detect empty turns:**
- If stream completes with no text content and no tool calls, yields:
  `"No response received. Check that your model server is running and the model name is correct."`

Errors are already rendered visibly in red in REPL.tsx (`✗ <message>`).

## Test plan
- [x] Point llamacpp baseUrl at a wrong port → see clear error instead of blank
- [x] Stop Ollama, run oh chat → see "Ollama: response body is not readable"
- [x] `npm test` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)