### PR TITLE
Fix: Add unit tests for provider fetchModels and healthCheck methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zhijiewang/openharness",
-  "version": "0.3.3",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zhijiewang/openharness",
-      "version": "0.3.3",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@types/marked": "^5.0.2",

--- a/src/providers/llamacpp.test.ts
+++ b/src/providers/llamacpp.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LlamaCppProvider } from "./llamacpp.js";
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+test("LlamaCppProvider.fetchModels() returns ModelInfo array from /v1/models", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+  const mockData = {
+    data: [
+      { id: "llama3-8b" },
+      { id: "mistral-7b" },
+    ],
+  };
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (url: string) => {
+    assert.equal(url, "http://localhost:8080/v1/models");
+    return mockResponse(mockData);
+  };
+  try {
+    const models = await provider.fetchModels();
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "llama3-8b");
+    assert.equal(models[0].provider, "llamacpp");
+    assert.equal(models[0].contextWindow, 128_000);
+    assert.equal(models[0].supportsTools, true);
+    assert.equal(models[0].supportsStreaming, true);
+    assert.equal(models[0].supportsVision, false);
+    assert.equal(models[0].inputCostPerMtok, 0);
+    assert.equal(models[0].outputCostPerMtok, 0);
+    assert.equal(models[1].id, "mistral-7b");
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.fetchModels() strips /v1 suffix from baseUrl before fetching", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080/v1" });
+  const mockData = { data: [{ id: "model-a" }] };
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (url: string) => {
+    // Should NOT produce /v1/v1/models
+    assert.equal(url, "http://localhost:8080/v1/models");
+    return mockResponse(mockData);
+  };
+  try {
+    const models = await provider.fetchModels();
+    assert.equal(models.length, 1);
+    assert.equal(models[0].id, "model-a");
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.fetchModels() returns empty array on non-OK response", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({}, 503);
+  try {
+    const models = await provider.fetchModels();
+    assert.deepEqual(models, []);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.fetchModels() returns empty array on fetch error", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+  try {
+    const models = await provider.fetchModels();
+    assert.deepEqual(models, []);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.healthCheck() returns true for 200 OK", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({}, 200);
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, true);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.healthCheck() returns false for 503", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({}, 503);
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, false);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("LlamaCppProvider.healthCheck() returns false on fetch error", async () => {
+  const provider = new LlamaCppProvider({ name: "llamacpp", baseUrl: "http://localhost:8080" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, false);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});

--- a/src/providers/ollama.test.ts
+++ b/src/providers/ollama.test.ts
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { OllamaProvider } from "./ollama.js";
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+test("OllamaProvider.fetchModels() returns ModelInfo array from /api/tags", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+  const mockData = {
+    models: [
+      { name: "llama3.1:latest", details: { families: [] } },
+      { name: "mistral:7b", details: { families: ["llama"] } },
+    ],
+  };
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (url: string) => {
+    assert.equal(url, "http://localhost:11434/api/tags");
+    return mockResponse(mockData);
+  };
+  try {
+    const models = await provider.fetchModels();
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "llama3.1:latest");
+    assert.equal(models[0].provider, "ollama");
+    assert.equal(models[0].contextWindow, 128_000);
+    assert.equal(models[0].supportsTools, true);
+    assert.equal(models[0].supportsStreaming, true);
+    assert.equal(models[0].supportsVision, false);
+    assert.equal(models[0].inputCostPerMtok, 0);
+    assert.equal(models[0].outputCostPerMtok, 0);
+    assert.equal(models[1].id, "mistral:7b");
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.fetchModels() detects vision support via clip family", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+  const mockData = {
+    models: [
+      { name: "llava:13b", details: { families: ["llama", "clip"] } },
+      { name: "regular:7b", details: { families: ["llama"] } },
+    ],
+  };
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse(mockData);
+  try {
+    const models = await provider.fetchModels();
+    assert.equal(models[0].supportsVision, true);
+    assert.equal(models[1].supportsVision, false);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.fetchModels() detects vision support via llava family", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+  const mockData = {
+    models: [
+      { name: "bakllava:latest", details: { families: ["llava"] } },
+    ],
+  };
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse(mockData);
+  try {
+    const models = await provider.fetchModels();
+    assert.equal(models[0].supportsVision, true);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.fetchModels() returns empty array on non-OK response", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({}, 503);
+  try {
+    const models = await provider.fetchModels();
+    assert.deepEqual(models, []);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.fetchModels() returns empty array on fetch error", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+  try {
+    const models = await provider.fetchModels();
+    assert.deepEqual(models, []);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.healthCheck() returns true for 200 OK", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({ models: [] }, 200);
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, true);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.healthCheck() returns false for 503", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => mockResponse({}, 503);
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, false);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("OllamaProvider.healthCheck() returns false on fetch error", async () => {
+  const provider = new OllamaProvider({ name: "ollama", baseUrl: "http://localhost:11434" });
+
+  const savedFetch = globalThis.fetch;
+  (globalThis as any).fetch = async () => { throw new Error("ECONNREFUSED"); };
+  try {
+    const healthy = await provider.healthCheck();
+    assert.equal(healthy, false);
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});


### PR DESCRIPTION
## What changed
Added unit tests for `LlamaCppProvider` and `OllamaProvider` in new files `src/providers/llamacpp.test.ts` and `src/providers/ollama.test.ts`.

Tests cover:
- `LlamaCppProvider.fetchModels()` — mocked `/v1/models` response, verifies ModelInfo shape, handles non-OK and fetch errors, verifies `/v1` suffix stripping
- `LlamaCppProvider.healthCheck()` — mocked 200 OK (returns true), 503 (returns false), and fetch error (returns false)
- `OllamaProvider.fetchModels()` — mocked `/api/tags` response, verifies ModelInfo shape, vision detection via `clip`/`llava` families, handles non-OK and fetch errors
- `OllamaProvider.healthCheck()` — same three scenarios as above

## Why
Fixes #10 — provider classes had no unit tests; only the harness/config layer was covered.

## Testing
- Used Node's built-in `node:test` and `node:assert/strict`, matching existing test patterns
- Mocked `globalThis.fetch` inline with save/restore pattern (no external dependencies)
- All 81 tests pass (`npm test`)
