### PR TITLE
fix: shell injection in git auto-commit and /model provider mismatch

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ import { writeFileSync, mkdirSync, readFileSync, existsSync, readdirSync } from 
 import { dirname } from "node:path";
 import { isGitRepo, gitDiff, gitUndo, gitCommit, gitLog, gitBranch } from "../git/index.js";
 import type { Message } from "../types/message.js";
+import { guessProviderFromModel } from "../providers/index.js";
 import { handleCybergotchiCommand } from "./cybergotchi.js";
 import { connectedMcpServers } from "../mcp/loader.js";
 import { listSessions, loadSession } from "../harness/session.js";
@@ -40,6 +41,7 @@ type CommandHandler = (args: string, context: CommandContext) => CommandResult;
 export type CommandContext = {
   messages: Message[];
   model: string;
+  providerName: string;
   permissionMode: string;
   totalCost: number;
   totalInputTokens: number;
@@ -193,10 +195,28 @@ register("files", "List files in context", (_args, ctx) => {
   return { output: `Files in context:\n${[...files].map(f => `  ${f}`).join("\n")}`, handled: true };
 });
 
-register("model", "Switch model (e.g., /model gpt-4o)", (args) => {
+register("model", "Switch model (e.g., /model llama3.2 or /model ollama/llama3.2)", (args, ctx) => {
   const model = args.trim();
-  if (!model) return { output: "Usage: /model <model-name>", handled: true };
-  return { output: `Switched to ${model}.`, handled: true, newModel: model };
+  if (!model) return { output: "Usage: /model <model-name>  (prefix with provider/ to switch providers)", handled: true };
+
+  // Detect the provider implied by the new model
+  let newProviderName: string;
+  if (model.includes("/")) {
+    newProviderName = model.split("/")[0]!;
+  } else {
+    newProviderName = guessProviderFromModel(model);
+  }
+
+  if (newProviderName !== ctx.providerName) {
+    return {
+      output: `Cannot switch to '${model}': requires the '${newProviderName}' provider but current session uses '${ctx.providerName}'.\nRestart with: oh --model ${newProviderName}/${model.includes("/") ? model.split("/").slice(1).join("/") : model}`,
+      handled: true,
+    };
+  }
+
+  // Strip provider prefix if present (provider is already correct)
+  const modelName = model.includes("/") ? model.split("/").slice(1).join("/") : model;
+  return { output: `Switched to ${modelName}.`, handled: true, newModel: modelName };
 });
 
 register("compact", "Compress conversation history", (_args, ctx) => {

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -384,6 +384,7 @@ export default function REPL({
         const ctx: CommandContext = {
           messages: messagesRef.current,
           model: currentModel,
+          providerName: provider.name,
           permissionMode,
           totalCost: costRef.current.totalCost,
           totalInputTokens: costRef.current.totalInputTokens,

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -95,7 +95,7 @@ export function autoCommitAIEdits(
       // Stage only the files the AI touched
       for (const file of files) {
         try {
-          execSync(`git add ${JSON.stringify(file)}`, { cwd, stdio: "pipe" });
+          spawnSync("git", ["add", "--", file], { cwd, stdio: "pipe" });
         } catch {
           // File might not exist (deleted)
         }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -41,7 +41,7 @@ export async function createProvider(
   return { provider, model };
 }
 
-export { createProviderInstance };
+export { createProviderInstance, guessProviderFromModel };
 
 function createProviderInstance(name: string, config: ProviderConfig): Provider {
   switch (name) {


### PR DESCRIPTION
## Summary

Two bugs found during code review, fixed together since both are small.

### 1. Shell injection in `autoCommitAIEdits` (`src/git/index.ts`)

`execSync(\`git add ${JSON.stringify(file)}\`)` wrapped the path in double quotes but did not escape the contents. A file path like `$(cat /etc/passwd)` becomes `git add "$(cat /etc/passwd)"` — bash executes the subexpression inside double quotes. The file path comes from AI tool call arguments, making this AI-controlled code execution.

**Fix:** replaced with `spawnSync("git", ["add", "--", file])` — no shell involved, same pattern already used elsewhere in the file.

### 2. `/model` silently uses wrong provider (`src/commands/index.ts`)

`/model gpt-4o` set `currentModel = "gpt-4o"` but the provider instance (e.g. Ollama) was never updated. The OpenAI model name was forwarded to Ollama which either failed silently or returned garbage.

**Fix:** the command now detects when the requested model implies a different provider (using the existing `guessProviderFromModel`) and returns a clear error with a restart hint. Same-provider switches still work as before.

## Test plan

- [ ] `src/git/index.ts`: verify `git add` is called via `spawnSync`, not shell interpolation
- [ ] Start `oh --model ollama/llama3`, run `/model gpt-4o` → error with restart hint
- [ ] Start `oh --model ollama/llama3`, run `/model llama3.2` → switches successfully
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)