### PR TITLE
fix: tier 1 bug fixes (8 issues)

### DIFF
--- a/docs/superpowers/plans/2026-04-04-tier1-bugs.md
+++ b/docs/superpowers/plans/2026-04-04-tier1-bugs.md
@@ -1,0 +1,579 @@
+# Tier 1 Bug Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 8 correctness/polish bugs found in code review, shipped as a single PR.
+
+**Architecture:** Each fix is independent and touches a single file. Order: cost.ts consolidation first (Task 1) because query.ts (Tasks 2, 6) imports from it; all others are standalone.
+
+**Tech Stack:** TypeScript, Node.js, Ink (React for terminal), Zod
+
+---
+
+### Task 1: Consolidate duplicate context window tables
+
+**Files:**
+- Modify: `src/harness/cost.ts:97-116`
+- Modify: `src/query.ts:411-445`
+
+- [ ] **Step 1: Add `getContextWindow` to `cost.ts`**
+
+  In `src/harness/cost.ts`, replace the `MODEL_CONTEXT_LIMITS` block (lines 97–116) with the merged map and add the exported helper:
+
+  ```ts
+  /** Context window sizes — prefix-matched, most-specific prefix first */
+  const CONTEXT_WINDOW_PREFIXES: Array<[string, number]> = [
+    // Anthropic
+    ["claude-", 200_000],
+    // OpenAI
+    ["gpt-4o", 128_000],
+    ["gpt-4-turbo", 128_000],
+    ["gpt-3.5", 16_000],
+    ["o1", 200_000],
+    ["o3", 200_000],
+    // Llama 3.x
+    ["llama3", 128_000],
+    ["llama-3", 128_000],
+    // Qwen
+    ["qwen2.5", 128_000],
+    ["qwen2", 128_000],
+    ["qwen-turbo", 131_072],
+    // Mistral / Mixtral
+    ["mistral", 32_000],
+    ["mixtral", 32_000],
+    // DeepSeek
+    ["deepseek", 64_000],
+    // Phi
+    ["phi", 128_000],
+    // Gemma
+    ["gemma2", 8_192],
+    ["gemma", 8_192],
+  ];
+
+  /** Returns the context window size in tokens for a given model name. */
+  export function getContextWindow(model?: string): number {
+    if (!model) return 8_192;
+    const lower = model.toLowerCase();
+    for (const [prefix, window] of CONTEXT_WINDOW_PREFIXES) {
+      if (lower.startsWith(prefix)) return window;
+    }
+    return 32_768;
+  }
+
+  /** Returns context usage as a fraction 0–1, or null if model unknown */
+  export function contextUsage(model: string, inputTokens: number): number | null {
+    const window = getContextWindow(model);
+    return inputTokens / window;
+  }
+  ```
+
+  Also delete the now-unused `MODEL_CONTEXT_LIMITS` export entirely (it was only used by `contextUsage` which is now merged above).
+
+- [ ] **Step 2: Update `query.ts` to import `getContextWindow` from `cost.ts`**
+
+  In `src/query.ts`:
+
+  1. Add import at the top (with other harness imports):
+     ```ts
+     import { getContextWindow } from "./harness/cost.js";
+     ```
+  2. Delete the `CONTEXT_WINDOW_PREFIXES` array (lines 411–436) and the local `getContextWindow` function (lines 438–445) entirely.
+
+- [ ] **Step 3: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/harness/cost.ts src/query.ts
+  git commit -m "refactor: consolidate context window tables into cost.ts"
+  ```
+
+---
+
+### Task 2: Fix `compressMessages` orphan tool results
+
+**Files:**
+- Modify: `src/query.ts:447-470`
+
+- [ ] **Step 1: Replace `compressMessages` with orphan-safe version**
+
+  In `src/query.ts`, replace the `compressMessages` function (lines 447–470) with:
+
+  ```ts
+  function compressMessages(messages: Message[], targetTokens: number): Message[] {
+    if (messages.length <= 2) return messages;
+
+    const result = [...messages];
+    const keepLast = 10;
+
+    // Phase 1: Truncate old tool results (keep last N)
+    let toolResultCount = 0;
+    for (let i = result.length - 1; i >= 0; i--) {
+      if (result[i]!.role === "tool") toolResultCount++;
+      if (result[i]!.role === "tool" && toolResultCount > keepLast) {
+        result[i] = { ...result[i]!, content: "[previous tool result truncated]" };
+      }
+    }
+
+    // Phase 2: If still over, drop oldest non-system messages
+    while (estimateMessagesTokens(result) > targetTokens && result.length > keepLast + 1) {
+      const firstNonSystem = result.findIndex((m) => m.role !== "system");
+      if (firstNonSystem === -1 || firstNonSystem >= result.length - keepLast) break;
+      result.splice(firstNonSystem, 1);
+    }
+
+    // Phase 3: Remove orphaned tool results — tool msgs with no preceding
+    // assistant message that issued the matching tool call. Sending orphaned
+    // tool results to Anthropic causes a 400 error.
+    const validCallIds = new Set<string>();
+    for (const msg of result) {
+      if (msg.role === "assistant" && msg.toolCalls) {
+        for (const tc of msg.toolCalls) validCallIds.add(tc.id);
+      }
+    }
+    return result.filter((msg) => {
+      if (msg.role !== "tool") return true;
+      return msg.toolResults?.every((tr) => validCallIds.has(tr.callId)) ?? true;
+    });
+  }
+  ```
+
+- [ ] **Step 2: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/query.ts
+  git commit -m "fix: remove orphaned tool results after message compression"
+  ```
+
+---
+
+### Task 3: Fix `WebFetchTool` redirect blocking
+
+**Files:**
+- Modify: `src/tools/WebFetchTool/index.ts:80-108`
+
+- [ ] **Step 1: Update the fetch call**
+
+  In `src/tools/WebFetchTool/index.ts`, replace the `try` block (lines 80–108):
+
+  ```ts
+  try {
+    const response = await fetch(input.url, {
+      headers: { "User-Agent": "OpenHarness/1.0" },
+      redirect: "follow",
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    // Re-check host after redirect to prevent SSRF via open redirects
+    const finalUrl = new URL(response.url);
+    if (isBlockedHost(finalUrl.hostname)) {
+      return { output: "Error: Redirect to private/internal host blocked.", isError: true };
+    }
+
+    if (!response.ok) {
+      return {
+        output: `Error: HTTP ${response.status} ${response.statusText}`,
+        isError: true,
+      };
+    }
+
+    let text = await response.text();
+    const contentType = response.headers.get("content-type") || "";
+
+    if (contentType.includes("html")) {
+      text = stripHtml(text);
+    }
+
+    if (text.length > MAX_OUTPUT) {
+      text = text.slice(0, MAX_OUTPUT) + "\n... [truncated]";
+    }
+
+    return { output: text, isError: false };
+  } catch (err: any) {
+    return { output: `Error fetching URL: ${err.message}`, isError: true };
+  }
+  ```
+
+- [ ] **Step 2: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/tools/WebFetchTool/index.ts
+  git commit -m "fix: allow WebFetch redirects, re-validate host after redirect"
+  ```
+
+---
+
+### Task 4: Fix sub-agent `permissionMode` inheritance
+
+**Files:**
+- Modify: `src/Tool.ts:15-27`
+- Modify: `src/tools/AgentTool/index.ts:34-42`
+- Modify: `src/query.ts:72-80`
+
+- [ ] **Step 1: Add `permissionMode` to `ToolContext`**
+
+  In `src/Tool.ts`, add `permissionMode` to the `ToolContext` type:
+
+  ```ts
+  export type ToolContext = {
+    workingDir: string;
+    abortSignal?: AbortSignal;
+    callId?: string;
+    onOutputChunk?: (callId: string, chunk: string) => void;
+    /** Available for sub-agent tools (AgentTool) */
+    provider?: Provider;
+    model?: string;
+    tools?: Tool[];
+    systemPrompt?: string;
+    /** Permission mode inherited from parent session */
+    permissionMode?: string;
+    /** Ask the user a question; resolves with their answer string */
+    askUserQuestion?: (question: string, options?: string[]) => Promise<string>;
+  };
+  ```
+
+- [ ] **Step 2: Thread `permissionMode` into `toolContext` in `query.ts`**
+
+  In `src/query.ts`, update the `toolContext` construction (lines 72–80):
+
+  ```ts
+  const toolContext: ToolContext = {
+    workingDir: process.cwd(),
+    abortSignal: config.abortSignal,
+    provider: config.provider,
+    model: config.model,
+    tools: config.tools,
+    systemPrompt: config.systemPrompt,
+    permissionMode: config.permissionMode,
+    askUserQuestion: config.askUserQuestion,
+  };
+  ```
+
+- [ ] **Step 3: Use `context.permissionMode` in `AgentTool`**
+
+  In `src/tools/AgentTool/index.ts`, replace the hardcoded `"trust"`:
+
+  ```ts
+  const config = {
+    provider: context.provider,
+    tools: context.tools,
+    systemPrompt,
+    permissionMode: (context.permissionMode ?? "trust") as PermissionMode,
+    model: context.model,
+    maxTurns: 20,
+    abortSignal: context.abortSignal,
+  };
+  ```
+
+  Also add the import at the top of the file:
+  ```ts
+  import type { PermissionMode } from "../../types/permissions.js";
+  ```
+
+- [ ] **Step 4: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/Tool.ts src/tools/AgentTool/index.ts src/query.ts
+  git commit -m "fix: sub-agent inherits permissionMode from parent instead of hardcoding trust"
+  ```
+
+---
+
+### Task 5: Cache `loadCybergotchiConfig()` in REPL
+
+**Files:**
+- Modify: `src/components/REPL.tsx`
+
+- [ ] **Step 1: Add `cybergotchiConfigRef` and replace all inline calls**
+
+  In `src/components/REPL.tsx`:
+
+  1. After the `showCybergotchiSetup` state declaration, add:
+     ```ts
+     const cybergotchiConfigRef = useRef(loadCybergotchiConfig());
+     ```
+
+  2. Replace line 132 (inside the `useEffect` that increments session count):
+     ```ts
+     // Before:
+     const cfg = loadCybergotchiConfig();
+     // After:
+     const cfg = cybergotchiConfigRef.current;
+     ```
+
+  3. Replace line 371 (inside `handleSubmit`, cybergotchi address check):
+     ```ts
+     // Before:
+     const gotchiCfg = loadCybergotchiConfig();
+     // After:
+     const gotchiCfg = cybergotchiConfigRef.current;
+     ```
+
+  4. Replace line 443 (render-path setup gate):
+     ```ts
+     // Before:
+     if (loadCybergotchiConfig() === null || showCybergotchiSetup) {
+     // After:
+     if (cybergotchiConfigRef.current === null || showCybergotchiSetup) {
+     ```
+
+  5. Replace line 516 (keybinding hint):
+     ```ts
+     // Before:
+     {loadCybergotchiConfig()?.name ? ` | @${loadCybergotchiConfig()!.name} to chat` : ""}
+     // After:
+     {cybergotchiConfigRef.current?.name ? ` | @${cybergotchiConfigRef.current.name} to chat` : ""}
+     ```
+
+  6. In the `onComplete` callback of `CybergotchiSetup` (where `setShowCybergotchiSetup(false)` is called), refresh the ref:
+     ```ts
+     // Before:
+     onComplete={() => setShowCybergotchiSetup(false)}
+     // After:
+     onComplete={() => { cybergotchiConfigRef.current = loadCybergotchiConfig(); setShowCybergotchiSetup(false); }}
+     ```
+
+- [ ] **Step 2: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/components/REPL.tsx
+  git commit -m "perf: cache cybergotchi config in ref to avoid disk reads on every render"
+  ```
+
+---
+
+### Task 6: Add 429 rate-limit retry with backoff
+
+**Files:**
+- Modify: `src/types/events.ts`
+- Modify: `src/query.ts`
+- Modify: `src/components/REPL.tsx`
+
+- [ ] **Step 1: Add `RateLimited` event type to `events.ts`**
+
+  In `src/types/events.ts`, add after `ErrorEvent`:
+
+  ```ts
+  export type RateLimited = {
+    readonly type: "rate_limited";
+    readonly retryIn: number;   // seconds
+    readonly attempt: number;   // 1-based
+  };
+  ```
+
+  And add `RateLimited` to the `StreamEvent` union:
+
+  ```ts
+  export type StreamEvent =
+    | TextDelta
+    | ToolCallStart
+    | ToolCallComplete
+    | ToolCallEnd
+    | ToolOutputDelta
+    | PermissionRequest
+    | AskUserRequest
+    | CostUpdate
+    | TurnComplete
+    | ErrorEvent
+    | RateLimited;
+  ```
+
+- [ ] **Step 2: Add `isRateLimitError` helper and retry logic to `query.ts`**
+
+  In `src/query.ts`, add a helper after the constants:
+
+  ```ts
+  const MAX_RATE_LIMIT_RETRIES = 3;
+
+  function isRateLimitError(err: Error): boolean {
+    const msg = err.message.toLowerCase();
+    return msg.includes("429") || msg.includes("rate limit") || msg.includes("too many requests");
+  }
+  ```
+
+  Then in the `catch` block of the LLM call (currently lines 181–216), add rate-limit handling **before** the existing network error check:
+
+  ```ts
+  } catch (err) {
+    streamError = err instanceof Error ? err : new Error(String(err));
+    state.consecutiveErrors++;
+
+    // Circuit breaker
+    if (state.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+      yield { type: "error", message: `Too many consecutive errors (${state.consecutiveErrors}): ${streamError.message}` };
+      yield { type: "turn_complete", reason: "error" };
+      return;
+    }
+
+    const errorMsg = streamError.message.toLowerCase();
+
+    // Rate limit → exponential backoff retry (max 3 attempts)
+    if (isRateLimitError(streamError)) {
+      const attempt = state.consecutiveErrors;
+      if (attempt <= MAX_RATE_LIMIT_RETRIES) {
+        const retryIn = Math.pow(2, attempt); // 2, 4, 8 seconds
+        yield { type: "rate_limited", retryIn, attempt };
+        await new Promise((r) => setTimeout(r, retryIn * 1000));
+        continue;
+      }
+      yield { type: "error", message: `Rate limit exceeded after ${MAX_RATE_LIMIT_RETRIES} retries.` };
+      yield { type: "turn_complete", reason: "error" };
+      return;
+    }
+
+    if (errorMsg.includes("prompt") && errorMsg.includes("long")) {
+      state.messages = compressMessages(state.messages, Math.floor(contextWindow * 0.5));
+      state.transition = "retry_prompt_too_long";
+      yield { type: "error", message: "Context too long, compressing history..." };
+      continue;
+    }
+
+    if (errorMsg.includes("network") || errorMsg.includes("fetch") || errorMsg.includes("econnrefused")) {
+      state.transition = "retry_network";
+      const delay = 1000 * Math.pow(2, state.consecutiveErrors - 1);
+      yield { type: "error", message: `Network error, retrying in ${delay / 1000}s...` };
+      await new Promise((r) => setTimeout(r, delay));
+      continue;
+    }
+
+    yield { type: "error", message: streamError.message };
+    yield { type: "turn_complete", reason: "error" };
+    return;
+  }
+  ```
+
+- [ ] **Step 3: Handle `rate_limited` event in `REPL.tsx`**
+
+  In `src/components/REPL.tsx`, in the `for await` loop over `query(...)` events, add a case for `rate_limited` in the `switch` statement:
+
+  ```ts
+  case "rate_limited":
+    setStreamingText(`⏳ Rate limited — retrying in ${event.retryIn}s… (attempt ${event.attempt}/${3})`);
+    break;
+  ```
+
+- [ ] **Step 4: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/types/events.ts src/query.ts src/components/REPL.tsx
+  git commit -m "fix: retry on 429 rate limit with exponential backoff (2s/4s/8s)"
+  ```
+
+---
+
+### Task 7: Add `llamacpp` to `guessProviderFromModel`
+
+**Files:**
+- Modify: `src/providers/index.ts:68-73`
+
+- [ ] **Step 1: Add `llamacpp` detection**
+
+  In `src/providers/index.ts`, update `guessProviderFromModel`:
+
+  ```ts
+  function guessProviderFromModel(model: string): string {
+    if (model.includes("gpt") || model.startsWith("o3")) return "openai";
+    if (model.includes("claude")) return "anthropic";
+    if (model.includes("gguf") || model.startsWith("llamacpp")) return "llamacpp";
+    if (model.includes("llama") || model.includes("mistral") || model.includes("phi") || model.includes("qwen")) return "ollama";
+    return "openai"; // default fallback
+  }
+  ```
+
+- [ ] **Step 2: Build**
+
+  ```bash
+  npm run build
+  ```
+  Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/providers/index.ts
+  git commit -m "fix: detect llamacpp provider from gguf/llamacpp model name prefixes"
+  ```
+
+---
+
+### Task 8: Close issue #9 — `oh models` baseUrl for Ollama (already fixed)
+
+- [ ] **Step 1: Verify fix in `main.tsx`**
+
+  Check `src/main.tsx` lines 270–274 — Ollama already displays `(http://localhost:11434)` when no config baseUrl is set. The fix was included in an earlier commit.
+
+- [ ] **Step 2: Close the GitHub issue**
+
+  ```bash
+  gh issue close 9 --comment "Already fixed: main.tsx shows Ollama's default baseUrl (http://localhost:11434) since commit 584c698. No code change needed."
+  ```
+
+---
+
+### Task 9: Open PR for all changes
+
+- [ ] **Step 1: Push branch and open PR**
+
+  ```bash
+  gh pr create \
+    --title "fix: tier 1 bug fixes (orphan tool results, WebFetch redirects, sub-agent permissions, 429 retry, perf/polish)" \
+    --body "$(cat <<'EOF'
+  ## Fixes
+
+  - **Orphan tool results after /compact** — Phase 3 post-pass removes tool result messages with no matching assistant tool call, preventing Anthropic 400 errors
+  - **WebFetch redirects** — changed \`redirect: \"error\"\` → \`\"follow\"\` with post-redirect SSRF host check
+  - **Sub-agent permissionMode** — inherits parent permissionMode instead of hardcoding \`\"trust\"\`
+  - **Cybergotchi config disk reads** — cached in \`useRef\`, loaded once on mount instead of every render
+  - **Context window tables** — consolidated into single \`getContextWindow()\` in \`cost.ts\`, deleted duplicate in \`query.ts\`
+  - **429 rate-limit retry** — exponential backoff (2s/4s/8s), user-visible status in spinner
+  - **\`llamacpp\` provider detection** — \`guessProviderFromModel\` now recognises \`.gguf\` and \`llamacpp\` prefixes (closes #7)
+  - **Issue #9 closed** — Ollama baseUrl already shown since commit 584c698
+
+  ## Test plan
+  - [ ] \`npm run build\` passes
+  - [ ] Start \`oh --model ollama/llama3\`, run \`/compact\`, verify no 400 errors
+  - [ ] Test WebFetch with an http:// URL that redirects to https://
+  - [ ] Verify rate-limit retry message appears when API returns 429
+  EOF
+  )"
+  ```

--- a/docs/superpowers/specs/2026-04-04-tier1-bugs-design.md
+++ b/docs/superpowers/specs/2026-04-04-tier1-bugs-design.md
@@ -1,0 +1,110 @@
+# Tier 1 Bug Fixes — Design Spec
+
+**Date:** 2026-04-04
+**Scope:** 8 correctness/polish fixes, shipped as a single PR
+
+---
+
+## 1. `compressMessages` Orphan Tool Results
+
+**File:** `src/query.ts`
+
+**Problem:** When `/compact` drops old messages by index, it can drop an assistant message that has `toolCalls` while retaining its corresponding `tool` result messages (or vice versa). Anthropic's API requires tool results to immediately follow the assistant message that issued the tool call — orphaned results cause a 400 error.
+
+**Fix:** Before dropping any assistant message that has `toolCalls`, also drop all `tool` result messages whose `toolResults[].callId` matches any of the assistant's `toolCalls[].id`. Likewise, if dropping a `tool` result message, drop the preceding assistant message that issued the call. Apply this as a post-pass after the existing keep-last-N logic: scan the compacted array, identify any orphaned tool results (no preceding assistant with matching toolCall id), and remove them.
+
+---
+
+## 2. `WebFetchTool` Redirect Blocking
+
+**File:** `src/tools/WebFetchTool/index.ts`
+
+**Problem:** `redirect: "error"` blocks all redirects including legitimate HTTPS upgrades (e.g. `http://github.com` → `https://github.com`), making the tool fail on most real-world URLs.
+
+**Fix:**
+1. Change `redirect: "error"` → `redirect: "follow"`
+2. After the fetch completes, extract the final URL from `response.url`
+3. Re-run `isBlockedHost` on the final URL's hostname to prevent SSRF via open redirects
+
+---
+
+## 3. Sub-agent `permissionMode` Inheritance
+
+**File:** `src/tools/AgentTool/index.ts`
+
+**Problem:** Sub-agents always run with `permissionMode: "trust"` regardless of the parent session's permission mode. A parent running in `deny` mode can be bypassed by any tool call that goes through AgentTool.
+
+**Fix:** Pass the parent's `permissionMode` from the tool execution context into the sub-agent's `QueryConfig`. The `AgentTool` receives context (including `permissionMode`) via its execution parameters — thread it through to the sub-agent query.
+
+---
+
+## 4. `loadCybergotchiConfig()` Disk Reads on Every Render
+
+**File:** `src/components/REPL.tsx`
+
+**Problem:** `loadCybergotchiConfig()` reads and parses a JSON file from disk. It is called on every Ink render (at minimum twice per render: once for the setup gate check, twice in the keybinding hint). During active streaming sessions, Ink re-renders many times per second.
+
+**Fix:**
+1. Load config once on mount into a `useRef`: `const cybergotchiConfigRef = useRef(loadCybergotchiConfig())`
+2. After any operation that saves config (cybergotchi setup completion), update the ref: `cybergotchiConfigRef.current = loadCybergotchiConfig()`
+3. Replace all inline `loadCybergotchiConfig()` calls in the render path with `cybergotchiConfigRef.current`
+
+---
+
+## 5. Duplicate Context Window Tables
+
+**Files:** `src/query.ts`, `src/harness/cost.ts`
+
+**Problem:** Two separate hardcoded lookup tables map model names to context window sizes. They use different matching strategies (prefix-based in `query.ts`, exact in `cost.ts`) and have diverged — models added to one are missing from the other.
+
+**Fix:**
+1. In `cost.ts`, consolidate into a single exported `MODEL_CONTEXT_WINDOWS` map with all known models
+2. Export a `getContextWindow(model: string): number` helper that does prefix-based matching (to handle versioned model names) with a sensible default (8192)
+3. In `query.ts`, delete `getContextWindow` and import from `cost.ts`
+
+---
+
+## 6. 429 Rate-Limit Retry with Backoff
+
+**File:** `src/query.ts`
+
+**Problem:** HTTP 429 responses are treated the same as any other error — the session stops and the user must manually retry.
+
+**Fix:**
+1. Add a new stream event type: `{ type: "rate_limited"; retryIn: number; attempt: number }`
+2. In the query loop, wrap `provider.stream()` in a retry loop (max 3 attempts)
+3. On 429 (detected from the error message or a new `isRateLimitError` helper): emit `rate_limited` event, wait `2^attempt * 1000ms` (2s, 4s, 8s), then retry
+4. In `REPL.tsx`, handle the `rate_limited` event: display "⏳ Rate limited — retrying in Xs…" in the spinner area using existing `streamingText` state
+5. If all 3 attempts fail, surface as a normal error
+
+**Retry delays:** 2s → 4s → 8s (exponential, no jitter needed for a CLI tool)
+
+---
+
+## 7. `llamacpp` in `guessProviderFromModel`
+
+**File:** `src/providers/index.ts`
+
+**Problem:** `guessProviderFromModel` doesn't recognise `llamacpp` model names, so users always need the `llamacpp/` prefix.
+
+**Fix:** Add detection before the default fallback:
+```ts
+if (model.includes("gguf") || model.startsWith("llamacpp")) return "llamacpp";
+```
+
+---
+
+## 8. Verify Issue #9 — `oh models` baseUrl for Ollama
+
+**File:** `src/commands/index.ts` or wherever `oh models` is implemented
+
+**Action:** Read the current `models` command implementation. If Ollama already shows its baseUrl (commit `584c698` may have fixed this), close the GitHub issue. If not, add the baseUrl display consistent with how `llamacpp` shows it.
+
+---
+
+## Delivery
+
+- Single PR targeting `main`
+- PR description lists all 8 fixes with one-line summaries
+- `npm run build` must pass
+- Manual smoke test: run `oh --model ollama/llama3`, verify no regressions in startup, `/compact`, WebFetch, and sub-agent tool calls

--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -22,6 +22,8 @@ export type ToolContext = {
   model?: string;
   tools?: Tool[];
   systemPrompt?: string;
+  /** Permission mode inherited from parent session */
+  permissionMode?: string;
   /** Ask the user a question; resolves with their answer string */
   askUserQuestion?: (question: string, options?: string[]) => Promise<string>;
 };

--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -4,7 +4,7 @@
  */
 
 import type { z } from "zod";
-import type { RiskLevel } from "./types/permissions.js";
+import type { PermissionMode, RiskLevel } from "./types/permissions.js";
 import type { Provider } from "./providers/base.js";
 
 export type ToolResult = {
@@ -23,7 +23,7 @@ export type ToolContext = {
   tools?: Tool[];
   systemPrompt?: string;
   /** Permission mode inherited from parent session */
-  permissionMode?: string;
+  permissionMode?: PermissionMode;
   /** Ask the user a question; resolves with their answer string */
   askUserQuestion?: (question: string, options?: string[]) => Promise<string>;
 };

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -519,7 +519,7 @@ export default function REPL({
         {/* Token context warning */}
         {(() => {
           const usage = contextUsage(currentModel, costRef.current.totalInputTokens);
-          if (!usage || usage < 0.75) return null;
+          if (usage < 0.75) return null;
           const critical = usage >= 0.9;
           return (
             <Text color={critical ? "yellow" : undefined} bold={critical} dimColor={!critical}>

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -110,6 +110,7 @@ export default function REPL({
   const [error, setError] = useState<string | null>(null);
   const [currentModel, setCurrentModel] = useState(model ?? "");
   const [showCybergotchiSetup, setShowCybergotchiSetup] = useState(false);
+  const cybergotchiConfigRef = useRef(loadCybergotchiConfig());
 
   // Print new finalized messages to stdout (outside Ink's live area) to prevent
   // Ink height miscounting from causing the cybergotchi panel to expand on each tick.
@@ -129,7 +130,7 @@ export default function REPL({
 
   // Increment session count on mount
   useEffect(() => {
-    const cfg = loadCybergotchiConfig();
+    const cfg = cybergotchiConfigRef.current;
     if (cfg) {
       cfg.lifetime.totalSessions += 1;
       saveCybergotchiConfig(cfg);
@@ -368,7 +369,7 @@ export default function REPL({
 
       // Check if user is addressing the cybergotchi
       {
-        const gotchiCfg = loadCybergotchiConfig();
+        const gotchiCfg = cybergotchiConfigRef.current;
         if (gotchiCfg) {
           const name = gotchiCfg.name.toLowerCase();
           const lower = trimmed.toLowerCase();
@@ -440,11 +441,11 @@ export default function REPL({
   );
 
   // Show cybergotchi setup if needed (first run or /cybergotchi reset)
-  if (loadCybergotchiConfig() === null || showCybergotchiSetup) {
+  if (cybergotchiConfigRef.current === null || showCybergotchiSetup) {
     return (
       <CybergotchiSetup
-        onComplete={() => setShowCybergotchiSetup(false)}
-        onSkip={() => setShowCybergotchiSetup(false)}
+        onComplete={() => { cybergotchiConfigRef.current = loadCybergotchiConfig(); setShowCybergotchiSetup(false); }}
+        onSkip={() => { cybergotchiConfigRef.current = loadCybergotchiConfig(); setShowCybergotchiSetup(false); }}
       />
     );
   }
@@ -513,7 +514,7 @@ export default function REPL({
         {/* Keybinding hints */}
         <Text dimColor>
           {"exit to quit"}{loading ? " | Ctrl+C to interrupt" : ""}
-          {loadCybergotchiConfig()?.name ? ` | @${loadCybergotchiConfig()!.name} to chat` : ""}
+          {cybergotchiConfigRef.current?.name ? ` | @${cybergotchiConfigRef.current!.name} to chat` : ""}
         </Text>
 
         {/* Token context warning */}

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -231,6 +231,10 @@ export default function REPL({
       try {
         for await (const event of query(prompt, config, messagesRef.current)) {
           switch (event.type) {
+            case "rate_limited":
+              setStreamingText(`⏳ Rate limited — retrying in ${event.retryIn}s… (attempt ${event.attempt}/3)`);
+              break;
+
             case "text_delta":
               accumulated += event.content;
               setStreamingText(accumulated);

--- a/src/harness/cost.ts
+++ b/src/harness/cost.ts
@@ -94,23 +94,47 @@ export function estimateCost(model: string, inputTokens: number, outputTokens: n
   return (inputTokens / 1_000_000) * pricing[0] + (outputTokens / 1_000_000) * pricing[1];
 }
 
-/** Context window sizes in tokens per model (approximate) */
-export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
-  "gpt-4o":            128_000,
-  "gpt-4o-mini":       128_000,
-  "o3-mini":           200_000,
-  "o3":                200_000,
-  "claude-sonnet-4-6": 200_000,
-  "claude-haiku-4-5":  200_000,
-  "claude-opus-4-6":   200_000,
-  "deepseek-chat":     64_000,
-  "deepseek-coder":    64_000,
-  "qwen-turbo":        131_072,
-};
+/** Context window sizes — prefix-matched, most-specific prefix first */
+const CONTEXT_WINDOW_PREFIXES: Array<[string, number]> = [
+  // Anthropic
+  ["claude-", 200_000],
+  // OpenAI
+  ["gpt-4o", 128_000],
+  ["gpt-4-turbo", 128_000],
+  ["gpt-3.5", 16_000],
+  ["o1", 200_000],
+  ["o3", 200_000],
+  // Llama 3.x
+  ["llama3", 128_000],
+  ["llama-3", 128_000],
+  // Qwen
+  ["qwen2.5", 128_000],
+  ["qwen2", 128_000],
+  ["qwen-turbo", 131_072],
+  // Mistral / Mixtral
+  ["mistral", 32_000],
+  ["mixtral", 32_000],
+  // DeepSeek
+  ["deepseek", 64_000],
+  // Phi
+  ["phi", 128_000],
+  // Gemma
+  ["gemma2", 8_192],
+  ["gemma", 8_192],
+];
 
-/** Returns context usage as a fraction 0–1, or null if model unknown */
+/** Returns the context window size in tokens for a given model name. */
+export function getContextWindow(model?: string): number {
+  if (!model) return 8_192;
+  const lower = model.toLowerCase();
+  for (const [prefix, window] of CONTEXT_WINDOW_PREFIXES) {
+    if (lower.startsWith(prefix)) return window;
+  }
+  return 32_768;
+}
+
+/** Returns context usage as a fraction 0–1 */
 export function contextUsage(model: string, inputTokens: number): number | null {
-  const limit = MODEL_CONTEXT_LIMITS[model];
-  if (!limit) return null;
-  return inputTokens / limit;
+  const window = getContextWindow(model);
+  return inputTokens / window;
 }

--- a/src/harness/cost.ts
+++ b/src/harness/cost.ts
@@ -134,7 +134,7 @@ export function getContextWindow(model?: string): number {
 }
 
 /** Returns context usage as a fraction 0–1 */
-export function contextUsage(model: string, inputTokens: number): number | null {
+export function contextUsage(model: string, inputTokens: number): number {
   const window = getContextWindow(model);
   return inputTokens / window;
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -68,6 +68,7 @@ function createProviderInstance(name: string, config: ProviderConfig): Provider 
 function guessProviderFromModel(model: string): string {
   if (model.includes("gpt") || model.startsWith("o3")) return "openai";
   if (model.includes("claude")) return "anthropic";
+  if (model.includes("gguf") || model.startsWith("llamacpp")) return "llamacpp";
   if (model.includes("llama") || model.includes("mistral") || model.includes("phi") || model.includes("qwen")) return "ollama";
   return "openai"; // default fallback
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -22,6 +22,7 @@ import type { AskUserFn, PermissionMode } from "./types/permissions.js";
 import { checkPermission } from "./types/permissions.js";
 import type { Provider } from "./providers/base.js";
 import { StreamingToolExecutor } from "./services/StreamingToolExecutor.js";
+import { getContextWindow } from "./harness/cost.js";
 
 // ── Configuration ──
 
@@ -408,41 +409,6 @@ function estimateMessagesTokens(messages: Message[]): number {
   }, 0);
 }
 
-const CONTEXT_WINDOW_PREFIXES: Array<[string, number]> = [
-  // Anthropic
-  ["claude-", 200_000],
-  // OpenAI
-  ["gpt-4o", 128_000],
-  ["gpt-4-turbo", 128_000],
-  ["gpt-3.5", 16_000],
-  ["o1", 200_000],
-  ["o3", 200_000],
-  // Llama 3.x — 128K context
-  ["llama3", 128_000],
-  ["llama-3", 128_000],
-  // Qwen 2.x
-  ["qwen2", 128_000],
-  ["qwen2.5", 128_000],
-  // Mistral / Mixtral
-  ["mistral", 32_000],
-  ["mixtral", 32_000],
-  // DeepSeek
-  ["deepseek", 64_000],
-  // Phi-3 / Phi-4
-  ["phi", 128_000],
-  // Gemma 2
-  ["gemma2", 8_192],
-  ["gemma", 8_192],
-];
-
-function getContextWindow(model?: string): number {
-  if (!model) return 8_192;
-  const lower = model.toLowerCase();
-  for (const [prefix, window] of CONTEXT_WINDOW_PREFIXES) {
-    if (lower.startsWith(prefix)) return window;
-  }
-  return 32_768; // conservative default
-}
 
 function compressMessages(messages: Message[], targetTokens: number): Message[] {
   if (messages.length <= 2) return messages;

--- a/src/query.ts
+++ b/src/query.ts
@@ -61,6 +61,12 @@ const DEFAULT_MAX_TURNS = 50;
 const MAX_CONSECUTIVE_ERRORS = 3;
 const MAX_TOOL_RESULT_CHARS = 100_000; // 100KB cap per tool result
 const CHARS_PER_TOKEN = 4; // rough estimation
+const MAX_RATE_LIMIT_RETRIES = 3;
+
+function isRateLimitError(err: Error): boolean {
+  const msg = err.message.toLowerCase();
+  return msg.includes("429") || msg.includes("rate limit") || msg.includes("too many requests");
+}
 
 // ── Main Entry ──
 
@@ -193,6 +199,20 @@ export async function* query(
 
       // Error recovery cascade
       const errorMsg = streamError.message.toLowerCase();
+
+      // Rate limit → exponential backoff retry (max 3 attempts)
+      if (isRateLimitError(streamError)) {
+        const attempt = state.consecutiveErrors;
+        if (attempt <= MAX_RATE_LIMIT_RETRIES) {
+          const retryIn = Math.pow(2, attempt); // 2, 4, 8 seconds
+          yield { type: "rate_limited", retryIn, attempt };
+          await new Promise((r) => setTimeout(r, retryIn * 1000));
+          continue;
+        }
+        yield { type: "error", message: `Rate limit exceeded after ${MAX_RATE_LIMIT_RETRIES} retries.` };
+        yield { type: "turn_complete", reason: "error" };
+        return;
+      }
 
       if (errorMsg.includes("prompt") && errorMsg.includes("long")) {
         // Prompt too long → compress and retry

--- a/src/query.ts
+++ b/src/query.ts
@@ -443,7 +443,8 @@ function compressMessages(messages: Message[], targetTokens: number): Message[] 
   }
   return result.filter((msg) => {
     if (msg.role !== "tool") return true;
-    return msg.toolResults?.every((tr) => validCallIds.has(tr.callId)) ?? true;
+    return (msg.toolResults?.length ?? 0) > 0 &&
+           msg.toolResults!.every((tr) => validCallIds.has(tr.callId));
   });
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -432,7 +432,19 @@ function compressMessages(messages: Message[], targetTokens: number): Message[] 
     result.splice(firstNonSystem, 1);
   }
 
-  return result;
+  // Phase 3: Remove orphaned tool results — tool msgs with no preceding
+  // assistant message that issued the matching tool call. Sending orphaned
+  // tool results to Anthropic causes a 400 error.
+  const validCallIds = new Set<string>();
+  for (const msg of result) {
+    if (msg.role === "assistant" && msg.toolCalls) {
+      for (const tc of msg.toolCalls) validCallIds.add(tc.id);
+    }
+  }
+  return result.filter((msg) => {
+    if (msg.role !== "tool") return true;
+    return msg.toolResults?.every((tr) => validCallIds.has(tr.callId)) ?? true;
+  });
 }
 
 export type { QueryLoopState };

--- a/src/query.ts
+++ b/src/query.ts
@@ -77,6 +77,7 @@ export async function* query(
     model: config.model,
     tools: config.tools,
     systemPrompt: config.systemPrompt,
+    permissionMode: config.permissionMode,
     askUserQuestion: config.askUserQuestion,
   };
   const toolPrompts = config.tools.map((t) => t.prompt()).join("\n\n");

--- a/src/tools/AgentTool/index.ts
+++ b/src/tools/AgentTool/index.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type { Tool, ToolResult, ToolContext } from "../../Tool.js";
-import type { PermissionMode } from "../../types/permissions.js";
 
 const inputSchema = z.object({
   prompt: z.string(),
@@ -36,7 +35,7 @@ export const AgentTool: Tool<typeof inputSchema> = {
       provider: context.provider,
       tools: context.tools,
       systemPrompt,
-      permissionMode: (context.permissionMode ?? "trust") as PermissionMode,
+      permissionMode: context.permissionMode ?? "trust",
       model: context.model,
       maxTurns: 20,
       abortSignal: context.abortSignal,

--- a/src/tools/AgentTool/index.ts
+++ b/src/tools/AgentTool/index.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Tool, ToolResult, ToolContext } from "../../Tool.js";
+import type { PermissionMode } from "../../types/permissions.js";
 
 const inputSchema = z.object({
   prompt: z.string(),
@@ -35,7 +36,7 @@ export const AgentTool: Tool<typeof inputSchema> = {
       provider: context.provider,
       tools: context.tools,
       systemPrompt,
-      permissionMode: "trust" as const, // sub-agents inherit trust from parent
+      permissionMode: (context.permissionMode ?? "trust") as PermissionMode,
       model: context.model,
       maxTurns: 20,
       abortSignal: context.abortSignal,

--- a/src/tools/WebFetchTool/index.ts
+++ b/src/tools/WebFetchTool/index.ts
@@ -80,9 +80,15 @@ export const WebFetchTool: Tool<typeof inputSchema> = {
     try {
       const response = await fetch(input.url, {
         headers: { "User-Agent": "OpenHarness/1.0" },
-        redirect: "error",  // Block redirects — prevents SSRF via redirect to private IPs
+        redirect: "follow",
         signal: AbortSignal.timeout(30_000),
       });
+
+      // Re-check host after redirect to prevent SSRF via open redirects
+      const finalUrl = new URL(response.url);
+      if (isBlockedHost(finalUrl.hostname)) {
+        return { output: "Error: Redirect to private/internal host blocked.", isError: true };
+      }
 
       if (!response.ok) {
         return {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -54,6 +54,12 @@ export type ErrorEvent = {
   readonly message: string;
 };
 
+export type RateLimited = {
+  readonly type: "rate_limited";
+  readonly retryIn: number;   // seconds
+  readonly attempt: number;   // 1-based
+};
+
 export type ToolOutputDelta = {
   readonly type: "tool_output_delta";
   readonly callId: string;
@@ -77,4 +83,5 @@ export type StreamEvent =
   | AskUserRequest
   | CostUpdate
   | TurnComplete
-  | ErrorEvent;
+  | ErrorEvent
+  | RateLimited;


### PR DESCRIPTION
## Fixes

- **Orphan tool results after /compact** — Phase 3 post-pass removes tool result messages with no matching assistant tool call, preventing Anthropic 400 errors (`src/query.ts`)
- **WebFetch redirects** — changed `redirect: "error"` → `"follow"` with post-redirect SSRF host re-validation (`src/tools/WebFetchTool/index.ts`)
- **Sub-agent permissionMode** — inherits parent permissionMode instead of hardcoding `"trust"`; `ToolContext.permissionMode` now typed as `PermissionMode` not `string` (`src/Tool.ts`, `src/tools/AgentTool/index.ts`, `src/query.ts`)
- **Cybergotchi config disk reads** — cached in `useRef`, loaded once on mount instead of on every render (`src/components/REPL.tsx`)
- **Duplicate context window tables** — consolidated into single `getContextWindow()` in `cost.ts`, deleted duplicate prefix table from `query.ts`; `contextUsage` return type corrected from `number | null` to `number` (`src/harness/cost.ts`, `src/query.ts`)
- **429 rate-limit retry** — exponential backoff (2s/4s/8s), user-visible status in spinner (`src/types/events.ts`, `src/query.ts`, `src/components/REPL.tsx`)
- **`llamacpp` provider detection** — `guessProviderFromModel` now recognises `.gguf` and `llamacpp` prefixes (closes #7) (`src/providers/index.ts`)
- **Issue #9 closed** — Ollama baseUrl already shown since commit 584c698

## Test plan
- [x] `npm run build` passes
- [x] Start `oh --model ollama/llama3`, run `/compact`, verify no 400 errors
- [x] Test WebFetch with an http:// URL that redirects to https://
- [x] Verify rate-limit retry message appears when API returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)