### PR TITLE
fix: prevent cybergotchi panel from overlapping chat text

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,64 @@ Type these during a chat session:
 | `/history [n]` | List recent sessions; `/history search <term>` to search |
 | `/files` | List files in context |
 | `/model <name>` | Switch model mid-session |
-| `/compact` | Compress conversation to free context |
+| `/compact` | Compress conversation to free context (smart: truncates old tool results, drops oldest messages, removes orphaned tool results, targets 60% of model context window) |
 | `/export` | Export conversation to markdown |
 | `/plan` | Enter plan mode |
 | `/review` | Review recent code changes |
 | `/config` | Show configuration |
 | `/memory` | View memories |
 | `/cybergotchi` | Feed, pet, rest, status, rename, or reset your companion |
+
+## Permission Modes
+
+Control how aggressively OpenHarness auto-approves tool calls:
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| `ask` | `--permission-mode ask` | Prompt for medium/high risk operations (default) |
+| `trust` | `--trust` | Auto-approve everything |
+| `deny` | `--deny` | Only allow low-risk read-only operations |
+| `acceptEdits` | `--permission-mode acceptEdits` | Auto-approve file edits, ask for Bash/WebFetch/Agent |
+| `plan` | `--permission-mode plan` | Read-only mode — block all write operations |
+
+Set permanently in `.oh/config.yaml`: `permissionMode: 'acceptEdits'`
+
+## Hooks
+
+Run shell scripts automatically at key session events by adding a `hooks` block to `.oh/config.yaml`:
+
+```yaml
+hooks:
+  - event: sessionStart
+    command: "echo 'Session started' >> ~/.oh/session.log"
+
+  - event: preToolUse
+    command: "scripts/check-tool.sh"
+    match: Bash   # optional: only trigger for this tool name
+
+  - event: postToolUse
+    command: "scripts/after-tool.sh"
+
+  - event: sessionEnd
+    command: "scripts/cleanup.sh"
+```
+
+**Event types:**
+- `sessionStart` — fires once when the session begins
+- `preToolUse` — fires before each tool call; **exit code 1 blocks the tool** and returns an error to the model
+- `postToolUse` — fires after each tool call completes
+- `sessionEnd` — fires when the session ends
+
+**Environment variables** available to hook scripts:
+
+| Variable | Description |
+|----------|-------------|
+| `OH_EVENT` | Event type (`sessionStart`, `preToolUse`, etc.) |
+| `OH_TOOL_NAME` | Name of the tool being called (tool events only) |
+| `OH_TOOL_ARGS` | JSON-encoded tool arguments (tool events only) |
+| `OH_TOOL_OUTPUT` | JSON-encoded tool output (`postToolUse` only) |
+
+Use `match` to restrict a hook to a specific tool name (e.g., `match: Bash` only triggers for the Bash tool).
 
 ## Cybergotchi
 
@@ -199,15 +250,18 @@ Exit code 0 on success, 1 on failure.
 ```bash
 # Local (free, no API key needed)
 oh --model ollama/llama3
-oh --model ollama/qwen2.5:7b-instruct
+oh --model ollama/qwen2.5:7b
 
 # Cloud
 OPENAI_API_KEY=sk-... oh --model gpt-4o
 ANTHROPIC_API_KEY=sk-ant-... oh --model claude-sonnet-4-6
-OPENROUTER_API_KEY=sk-or-... oh --model openrouter/deepseek-chat
+OPENROUTER_API_KEY=sk-or-... oh --model openrouter/meta-llama/llama-3-70b
 
-# Any OpenAI-compatible endpoint
-oh --model deepseek/deepseek-chat
+# llama.cpp / GGUF
+oh --model llamacpp/my-model
+
+# LM Studio
+oh --model lmstudio/my-model
 ```
 
 ### llama.cpp / GGUF (local, no Ollama needed)

--- a/docs/superpowers/plans/2026-04-05-v050-features.md
+++ b/docs/superpowers/plans/2026-04-05-v050-features.md
@@ -1,0 +1,714 @@
+# v0.5.0 Features Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add README docs for new features, session resume/fork, extended thinking support for 3 provider families, and MCP server improvements.
+
+**Architecture:** README is pure docs. Session fork adds `getLastSessionId()` + CLI flags. Extended thinking adds `thinking_delta` event type and per-provider parsing. MCP improvements are config + runtime changes in the mcp/ module.
+
+**Tech Stack:** TypeScript, Node.js, Ink/React, Commander.js CLI, JSON-RPC (MCP)
+
+---
+
+### Task 1: README documentation updates
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add Permission Modes section**
+
+After the existing "Quick Start" or provider mentions, add a new `## Permission Modes` section:
+
+```markdown
+## Permission Modes
+
+Control what tools can do without prompting:
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| `ask` | `--permission-mode ask` | Prompt for medium/high risk operations (default) |
+| `trust` | `--trust` | Auto-approve everything |
+| `deny` | `--deny` | Only allow low-risk read-only operations |
+| `acceptEdits` | `--permission-mode acceptEdits` | Auto-approve file edits, ask for Bash/WebFetch/Agent |
+| `plan` | `--permission-mode plan` | Read-only mode — block all write operations |
+
+Set permanently in `.oh/config.yaml`:
+\```yaml
+permissionMode: 'acceptEdits'
+\```
+```
+
+- [ ] **Step 2: Add Hooks section**
+
+Add a `## Hooks` section:
+
+```markdown
+## Hooks
+
+Run shell commands on lifecycle events. Configure in `.oh/config.yaml`:
+
+\```yaml
+hooks:
+  sessionStart:
+    - command: "echo session started"
+  preToolUse:
+    - match: "Bash"
+      command: "./scripts/validate-bash.sh"
+  postToolUse:
+    - command: "echo tool completed"
+  sessionEnd:
+    - command: "echo goodbye"
+\```
+
+**Events:**
+- `sessionStart` / `sessionEnd` — session lifecycle
+- `preToolUse` — runs before tool execution. Exit code 1 blocks the tool call.
+- `postToolUse` — runs after tool completes
+
+**Environment variables:** `OH_EVENT`, `OH_TOOL_NAME`, `OH_TOOL_ARGS`, `OH_TOOL_OUTPUT`
+
+Use `match` to filter by tool name (substring match).
+```
+
+- [ ] **Step 3: Update /compact description and add provider examples**
+
+Find the `/compact` entry in the Slash Commands table and update its description to: "Smart compression — truncates old tool results, drops oldest messages, removes orphaned tool results. Targets 60% of model context window."
+
+Add usage examples under each provider in the Providers section:
+```
+# Ollama (local, free)
+oh --model ollama/llama3
+oh --model ollama/qwen2.5:7b
+
+# OpenAI (needs OPENAI_API_KEY)
+OPENAI_API_KEY=sk-... oh --model gpt-4o
+
+# Anthropic (needs ANTHROPIC_API_KEY)
+ANTHROPIC_API_KEY=sk-ant-... oh --model claude-sonnet-4-6
+
+# OpenRouter (needs OPENROUTER_API_KEY)
+OPENROUTER_API_KEY=sk-or-... oh --model openrouter/meta-llama/llama-3-70b
+
+# llama.cpp (local server)
+oh --model llamacpp/my-model
+
+# LM Studio (local server on port 1234)
+oh --model lmstudio/my-model
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add permission modes, hooks, provider examples to README"
+```
+
+---
+
+### Task 2: Session — `getLastSessionId` helper
+
+**Files:**
+- Modify: `src/harness/session.ts`
+
+- [ ] **Step 1: Add `getLastSessionId` function**
+
+Append to `src/harness/session.ts`:
+
+```ts
+/** Returns the ID of the most recently updated session, or null if none exist. */
+export function getLastSessionId(dir?: string): string | null {
+  const sessions = listSessions(dir);
+  return sessions.length > 0 ? sessions[0]!.id : null;
+}
+```
+
+(`listSessions` already sorts by `updatedAt` descending, so index 0 is the most recent.)
+
+- [ ] **Step 2: Build**
+
+```bash
+npm run build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/harness/session.ts
+git commit -m "feat: add getLastSessionId helper for --continue flag"
+```
+
+---
+
+### Task 3: Session — `--continue` and `--fork` CLI flags + `/fork` command
+
+**Files:**
+- Modify: `src/main.tsx`
+- Modify: `src/commands/index.ts`
+- Modify: `src/components/App.tsx` (if it exists) or wherever `resumeSessionId` is passed
+
+- [ ] **Step 1: Add CLI flags to chat command in `main.tsx`**
+
+Find the `chat` command definition (around line 161). Add two new options after `--resume`:
+
+```ts
+  .option("--continue", "Resume the most recent session")
+  .option("--fork <id>", "Fork (branch) from an existing session")
+```
+
+In the action handler (after `opts` is available), resolve the session ID:
+
+```ts
+    // Session handling: --continue, --fork, --resume
+    let resumeSessionId: string | undefined = opts.resume as string | undefined;
+    let initialMessages: Message[] | undefined;
+
+    if (opts.continue) {
+      const { getLastSessionId } = await import("./harness/session.js");
+      const lastId = getLastSessionId();
+      if (lastId) {
+        resumeSessionId = lastId;
+      } else {
+        console.log("  No previous sessions found.");
+      }
+    }
+
+    if (opts.fork) {
+      const { loadSession, createSession: createSess } = await import("./harness/session.js");
+      try {
+        const source = loadSession(opts.fork as string);
+        initialMessages = source.messages;
+        console.log(`  Forked from session ${opts.fork} (${source.messages.length} messages)`);
+      } catch {
+        console.log(`  Session ${opts.fork} not found.`);
+      }
+    }
+```
+
+Then update the `render()` call to pass `initialMessages`:
+
+```ts
+    render(
+      <App
+        provider={provider}
+        tools={tools}
+        permissionMode={effectivePermMode}
+        model={resolvedModel}
+        resumeSessionId={resumeSessionId}
+        initialMessages={initialMessages}
+      />,
+    );
+```
+
+Also add the `Message` import at the top if not already present:
+```ts
+import type { Message } from "./types/message.js";
+```
+
+- [ ] **Step 2: Check App component accepts `initialMessages` prop**
+
+Read `src/components/App.tsx` (or wherever the App component is). Check if it accepts and passes through `initialMessages` to REPL. If not, add the prop.
+
+- [ ] **Step 3: Add `/fork` slash command in `commands/index.ts`**
+
+Add after the existing `/resume` command:
+
+```ts
+register("fork", "Fork current session (create a branch you can resume later)", (_args, ctx) => {
+  const { createSession, saveSession } = require("../harness/session.js");
+  const forked = createSession("", "");
+  forked.messages = [...ctx.messages];
+  const path = saveSession(forked);
+  return {
+    output: `Session forked as ${forked.id}. Resume later with: oh --resume ${forked.id}`,
+    handled: true,
+  };
+});
+```
+
+Note: Use dynamic import if the project uses ESM. Check how other commands import session utilities — follow the same pattern.
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+npm run build
+git add src/main.tsx src/commands/index.ts src/components/App.tsx
+git commit -m "feat: add --continue, --fork flags and /fork slash command"
+```
+
+---
+
+### Task 4: Extended thinking — event type
+
+**Files:**
+- Modify: `src/types/events.ts`
+
+- [ ] **Step 1: Add ThinkingDelta type**
+
+In `src/types/events.ts`, add after the existing `ErrorEvent` and `RateLimited` types:
+
+```ts
+export type ThinkingDelta = {
+  readonly type: "thinking_delta";
+  readonly content: string;
+};
+```
+
+Add `ThinkingDelta` to the `StreamEvent` union:
+
+```ts
+export type StreamEvent =
+  | TextDelta
+  | ToolCallStart
+  | ToolCallComplete
+  | ToolCallEnd
+  | ToolOutputDelta
+  | PermissionRequest
+  | AskUserRequest
+  | CostUpdate
+  | TurnComplete
+  | ErrorEvent
+  | RateLimited
+  | ThinkingDelta;
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build
+git add src/types/events.ts
+git commit -m "feat: add ThinkingDelta stream event type"
+```
+
+---
+
+### Task 5: Extended thinking — Anthropic provider
+
+**Files:**
+- Modify: `src/providers/anthropic.ts`
+
+- [ ] **Step 1: Add thinking parameter to request body**
+
+In the `stream()` method, after the body is constructed (around line 99-107), add thinking support:
+
+```ts
+    // Enable extended thinking for Claude models
+    body.thinking = { type: "enabled", budget_tokens: 10000 };
+```
+
+- [ ] **Step 2: Add thinking block parsing to SSE handler**
+
+In the SSE parsing loop, add a tracking variable near `currentToolId`:
+
+```ts
+    let inThinkingBlock = false;
+```
+
+In the `switch (currentEvent)` block, update `content_block_start`:
+
+```ts
+case "content_block_start": {
+  const block = data.content_block;
+  if (block?.type === "tool_use") {
+    currentToolId = block.id;
+    currentToolName = block.name;
+    currentToolArgs = "";
+    yield {
+      type: "tool_call_start",
+      toolName: block.name,
+      callId: block.id,
+    };
+  }
+  if (block?.type === "thinking") {
+    inThinkingBlock = true;
+  }
+  break;
+}
+```
+
+Update `content_block_delta` to handle thinking deltas:
+
+```ts
+case "content_block_delta": {
+  const delta = data.delta;
+  if (delta?.type === "text_delta" && delta.text) {
+    yield { type: "text_delta", content: delta.text };
+  }
+  if (delta?.type === "thinking_delta" && delta.thinking) {
+    yield { type: "thinking_delta", content: delta.thinking };
+  }
+  if (delta?.type === "input_json_delta" && delta.partial_json) {
+    currentToolArgs += delta.partial_json;
+  }
+  break;
+}
+```
+
+Update `content_block_stop` to reset thinking state:
+
+```ts
+case "content_block_stop": {
+  inThinkingBlock = false;
+  if (currentToolId) {
+    yield {
+      type: "tool_call_complete",
+      callId: currentToolId,
+      toolName: currentToolName,
+      arguments: currentToolArgs ? JSON.parse(currentToolArgs) : {},
+    } satisfies ToolCallComplete;
+    currentToolId = "";
+    currentToolName = "";
+    currentToolArgs = "";
+  }
+  break;
+}
+```
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+npm run build
+git add src/providers/anthropic.ts
+git commit -m "feat: Anthropic extended thinking support"
+```
+
+---
+
+### Task 6: Extended thinking — OpenAI o-series
+
+**Files:**
+- Modify: `src/providers/openai.ts`
+
+- [ ] **Step 1: Add reasoning support for o1/o3 models**
+
+In the `stream()` method, after the request body is built, add reasoning effort for o-series models:
+
+```ts
+    // Enable reasoning for o-series models
+    if (m.startsWith("o1") || m.startsWith("o3")) {
+      body.reasoning_effort = "medium";
+    }
+```
+
+In the SSE parsing loop where `delta.content` is checked, add `reasoning_content` parsing:
+
+```ts
+    // After: if (delta.content) { yield { type: "text_delta", ... }; }
+    if (delta.reasoning_content) {
+      yield { type: "thinking_delta" as const, content: delta.reasoning_content };
+    }
+```
+
+Find the exact location by searching for `delta.content` in the stream parsing section.
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build
+git add src/providers/openai.ts
+git commit -m "feat: OpenAI o-series reasoning token support"
+```
+
+---
+
+### Task 7: Extended thinking — Ollama `<think>` tags
+
+**Files:**
+- Modify: `src/providers/ollama.ts`
+
+- [ ] **Step 1: Add think tag parsing to stream handler**
+
+In the `stream()` method, add state tracking variables near the top of the method:
+
+```ts
+    let inThinkBlock = false;
+    let thinkBuffer = "";
+```
+
+In the SSE/streaming loop where `text_delta` events are yielded (find the line that yields `{ type: "text_delta", content: ... }`), replace the simple yield with think-tag-aware parsing:
+
+```ts
+    // Replace simple text_delta yield with think-tag parsing
+    if (typeof content === "string" && content) {
+      let remaining = content;
+
+      while (remaining.length > 0) {
+        if (inThinkBlock) {
+          const closeIdx = remaining.indexOf("</think>");
+          if (closeIdx !== -1) {
+            thinkBuffer += remaining.slice(0, closeIdx);
+            if (thinkBuffer) {
+              yield { type: "thinking_delta" as const, content: thinkBuffer };
+            }
+            thinkBuffer = "";
+            inThinkBlock = false;
+            remaining = remaining.slice(closeIdx + "</think>".length);
+          } else {
+            thinkBuffer += remaining;
+            remaining = "";
+          }
+        } else {
+          const openIdx = remaining.indexOf("<think>");
+          if (openIdx !== -1) {
+            if (openIdx > 0) {
+              yield { type: "text_delta", content: remaining.slice(0, openIdx) };
+            }
+            inThinkBlock = true;
+            remaining = remaining.slice(openIdx + "<think>".length);
+          } else {
+            yield { type: "text_delta", content: remaining };
+            remaining = "";
+          }
+        }
+      }
+    }
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+npm run build
+git add src/providers/ollama.ts
+git commit -m "feat: Ollama <think> tag parsing for extended thinking"
+```
+
+---
+
+### Task 8: Extended thinking — UI display in REPL
+
+**Files:**
+- Modify: `src/components/REPL.tsx`
+
+- [ ] **Step 1: Add thinkingText state and handle thinking_delta events**
+
+Add state:
+```ts
+const [thinkingText, setThinkingText] = useState("");
+```
+
+In the `for await` loop over `query(...)` events, add a case in the switch:
+
+```ts
+case "thinking_delta":
+  setThinkingText((prev) => prev + event.content);
+  break;
+```
+
+Also clear `thinkingText` at the start of each query (where `setStreamingText("")` is called):
+```ts
+setThinkingText("");
+```
+
+- [ ] **Step 2: Add thinking display to JSX**
+
+In the render return, above the streaming response display, add:
+
+```tsx
+{/* Thinking */}
+{thinkingText && (
+  <Box marginY={0}>
+    <Text dimColor>{"💭 "}{thinkingText.length > 200 ? thinkingText.slice(-200) + "…" : thinkingText}</Text>
+  </Box>
+)}
+```
+
+- [ ] **Step 3: Print finalized thinking to stdout**
+
+In the `printMessageToStdout` function (or wherever finalized messages are printed), thinking text doesn't need special handling — it's transient UI only. But clear it on `turn_complete`:
+
+In the `turn_complete` case in the switch, add:
+```ts
+setThinkingText("");
+```
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+npm run build
+git add src/components/REPL.tsx
+git commit -m "feat: display extended thinking in dimmed text above response"
+```
+
+---
+
+### Task 9: MCP improvements — risk levels, timeout, auto-restart
+
+**Files:**
+- Modify: `src/harness/config.ts`
+- Modify: `src/mcp/McpTool.ts`
+- Modify: `src/mcp/client.ts`
+- Modify: `src/mcp/loader.ts`
+
+- [ ] **Step 1: Add riskLevel and timeout to McpServerConfig**
+
+In `src/harness/config.ts`, update `McpServerConfig`:
+
+```ts
+export type McpServerConfig = {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  riskLevel?: "low" | "medium" | "high";
+  timeout?: number; // ms, default 5000
+};
+```
+
+- [ ] **Step 2: Use server riskLevel in McpTool**
+
+In `src/mcp/McpTool.ts`, change the constructor to accept a risk level:
+
+```ts
+export class McpTool implements Tool<z.ZodType> {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: z.ZodType;
+  readonly riskLevel: "low" | "medium" | "high";
+
+  private client: McpClient;
+  private def: McpToolDef;
+
+  constructor(client: McpClient, def: McpToolDef, riskLevel: "low" | "medium" | "high" = "medium") {
+    this.client = client;
+    this.def = def;
+    this.name = `${client.name}__${def.name}`;
+    this.description = def.description ?? def.name;
+    this.riskLevel = riskLevel;
+    // ... rest of constructor unchanged
+```
+
+- [ ] **Step 3: Pass timeout to McpClient.connect and add auto-restart**
+
+In `src/mcp/client.ts`, add a `dead` flag and restart logic:
+
+```ts
+export class McpClient {
+  readonly name: string;
+  private proc: ChildProcess;
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>();
+  private ready = false;
+  private dead = false;
+  private cfg: McpServerConfig;
+  private timeoutMs: number;
+```
+
+Update the constructor to store config:
+
+```ts
+  private constructor(name: string, proc: ChildProcess, cfg: McpServerConfig, timeoutMs: number) {
+    this.name = name;
+    this.proc = proc;
+    this.cfg = cfg;
+    this.timeoutMs = timeoutMs;
+    // ... existing rl/event setup
+
+    proc.on('exit', () => {
+      this.dead = true;
+      for (const p of this.pending.values()) {
+        p.reject(new Error(`MCP server '${name}' exited`));
+      }
+      this.pending.clear();
+    });
+  }
+```
+
+Update `connect`:
+```ts
+  static async connect(cfg: McpServerConfig, timeoutMs?: number): Promise<McpClient> {
+    const timeout = timeoutMs ?? cfg.timeout ?? 5_000;
+    const proc = spawn(cfg.command, cfg.args ?? [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...(cfg.env ?? {}) },
+    });
+    const client = new McpClient(cfg.name, proc, cfg, timeout);
+    // ... rest of handshake uses timeout
+```
+
+Add auto-restart in `callTool`:
+```ts
+  async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    // Auto-restart if server died
+    if (this.dead) {
+      try {
+        const restarted = await McpClient.connect(this.cfg, this.timeoutMs);
+        this.proc = restarted.proc;
+        this.dead = false;
+        this.ready = true;
+        this.nextId = restarted.nextId;
+        this.pending = restarted.pending;
+      } catch {
+        throw new Error(`MCP server '${this.name}' is dead and restart failed`);
+      }
+    }
+    // ... existing callTool logic
+```
+
+- [ ] **Step 4: Update loader to pass riskLevel and timeout**
+
+In `src/mcp/loader.ts`, update the tool creation:
+
+```ts
+    for (const server of servers) {
+      try {
+        const client = await McpClient.connect(server);
+        connectedClients.push(client);
+        const defs = await client.listTools();
+        for (const def of defs) {
+          tools.push(new McpTool(client, def, server.riskLevel));
+        }
+      } catch (err) {
+```
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+npm run build
+git add src/harness/config.ts src/mcp/McpTool.ts src/mcp/client.ts src/mcp/loader.ts
+git commit -m "feat: MCP per-tool risk levels, configurable timeout, auto-restart"
+```
+
+---
+
+### Task 10: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+git push -u origin feat/v050-features
+gh pr create --title "feat: README docs, session fork, extended thinking, MCP improvements" --body "$(cat <<'EOF'
+## Summary
+
+### Documentation
+- Permission modes table (all 5 modes)
+- Hooks configuration guide with event types and env vars
+- Updated /compact description
+- Provider usage examples for all 6 providers (closes #8)
+
+### Session Resume/Fork
+- `--continue` flag: resume most recent session
+- `--fork <id>` flag: branch from existing session with fresh ID
+- `/fork` command: snapshot current session for later resume
+
+### Extended Thinking
+- New `thinking_delta` stream event type
+- **Anthropic**: thinking blocks with 10K token budget
+- **OpenAI**: o1/o3 reasoning_content parsing
+- **Ollama**: `<think>` tag detection and buffering
+- **UI**: dimmed thinking text above streaming response
+
+### MCP Improvements
+- Per-server `riskLevel` config (was hardcoded "medium")
+- Configurable `timeout` per server
+- Auto-restart on server crash (one attempt)
+
+## Test plan
+- [ ] `npm run build` passes
+- [ ] `oh --continue` resumes last session
+- [ ] `oh --fork <id>` creates new session with old messages
+- [ ] Anthropic thinking blocks display as dimmed text
+- [ ] MCP server with custom riskLevel and timeout works
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-05-v050-features-design.md
+++ b/docs/superpowers/specs/2026-04-05-v050-features-design.md
@@ -1,0 +1,163 @@
+# v0.5.0 Features Design Spec
+
+**Date:** 2026-04-05
+**Scope:** README docs, session resume/fork, extended thinking, MCP improvements
+
+---
+
+## 1. README Documentation Updates
+
+**Goal:** Document new v0.5.0 features and add provider usage examples (closes #8).
+
+### Permission Modes Section
+
+Add after the Quick Start section. Table of all 5 modes:
+
+| Mode | Behavior |
+|------|----------|
+| `trust` | Auto-approve everything |
+| `ask` | Prompt for medium/high risk operations (default) |
+| `deny` | Only allow low-risk read-only operations |
+| `acceptEdits` | Auto-approve file operations, ask for Bash/WebFetch/Agent |
+| `plan` | Read-only mode — block all write operations |
+
+Usage: `oh --permission-mode acceptEdits` or set in `.oh/config.yaml`.
+
+### Hooks Section
+
+New section with config example showing all 4 event types, explanation of preToolUse blocking (exit code 1), environment variables (`OH_EVENT`, `OH_TOOL_NAME`, `OH_TOOL_ARGS`, `OH_TOOL_OUTPUT`).
+
+### /compact Update
+
+Update the existing `/compact` entry to mention smart compression: truncates old tool results first, drops oldest messages, removes orphaned tool results, targets 60% of model context window.
+
+### Provider Examples
+
+Add usage examples for each provider inline in the Providers section: Ollama, OpenAI, Anthropic, OpenRouter, llama.cpp, LM Studio. Include `--model` flag syntax and env var for API keys.
+
+---
+
+## 2. Session Resume/Fork
+
+**Goal:** Add `--continue` and `--fork` CLI flags, plus `/fork` slash command.
+
+### `--continue` Flag
+
+Resume the most recent session without needing to know the session ID.
+
+**Implementation:**
+- Add `getLastSessionId()` to `src/harness/session.ts` — reads session files from `~/.oh/sessions/`, returns the one with the most recent timestamp
+- Add `--continue` flag to the `chat` command in `main.tsx`
+- When set, call `getLastSessionId()` and pass as `resumeSessionId` to the REPL
+
+### `--fork <id>` Flag
+
+Create a new session branching from an existing one.
+
+**Implementation:**
+- In `main.tsx`, when `--fork <id>` is provided: load the source session, create a new session with a fresh ID, copy the messages array from the source
+- Pass to REPL as a normal session with `initialMessages` set
+
+### `/fork` Slash Command
+
+Fork the current session mid-conversation.
+
+**Implementation:**
+- In `commands/index.ts`, register `/fork` command
+- Creates a new session with current messages, saves it, returns the new session ID
+- The current session continues unchanged — the fork is a snapshot the user can resume later with `--resume <id>`
+
+---
+
+## 3. Extended Thinking Support
+
+**Goal:** Display model thinking/reasoning in a dimmed format above the response for Anthropic, OpenAI o-series, and Ollama models.
+
+### New Stream Event
+
+Add to `src/types/events.ts`:
+```ts
+export type ThinkingDelta = {
+  readonly type: "thinking_delta";
+  readonly content: string;
+};
+```
+
+Add `ThinkingDelta` to the `StreamEvent` union.
+
+### Anthropic Provider
+
+In `src/providers/anthropic.ts`:
+- When model starts with `claude-` (all Claude models support thinking), add `thinking: { type: "enabled", budget_tokens: 10000 }` to the request body
+- Parse `content_block_start` where `content_block.type === "thinking"` — set a flag `inThinkingBlock = true`
+- When `inThinkingBlock` and `content_block_delta` has `delta.type === "thinking_delta"`, yield `{ type: "thinking_delta", content: delta.thinking }`
+- On `content_block_stop`, reset `inThinkingBlock = false`
+
+### OpenAI Provider
+
+In `src/providers/openai.ts`:
+- For o1/o3 models, set `reasoning_effort: "medium"` in the request body
+- In streaming, check for `delta.reasoning_content` — if present, yield `{ type: "thinking_delta", content: delta.reasoning_content }`
+
+### Ollama Provider
+
+In `src/providers/ollama.ts`:
+- Buffer incoming `text_delta` content
+- Detect `<think>` opening tag — start buffering to a thinking accumulator instead of yielding text_delta
+- Detect `</think>` closing tag — yield accumulated content as `thinking_delta`, resume normal text_delta
+- Handle partial tags across chunk boundaries with a simple state machine
+
+### UI Display
+
+In `src/components/REPL.tsx`:
+- Add `thinkingText` state alongside `streamingText`
+- On `thinking_delta` events: append to `thinkingText`
+- Display above the streaming response as dimmed text: `💭 {thinkingText}` with `<Text dimColor>`
+- Clear `thinkingText` when turn completes
+
+### Config
+
+Add `thinking: boolean` to `OhConfig` in `config.ts`. Default: `true`. When `false`, skip thinking parameters in provider requests (saves tokens/cost).
+
+---
+
+## 4. MCP Server Improvements
+
+**Goal:** Per-tool risk levels, configurable timeout, auto-restart on crash.
+
+### Per-Tool Risk Level
+
+In `src/harness/config.ts`, add optional `riskLevel` to `McpServerConfig`:
+```ts
+export type McpServerConfig = {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  riskLevel?: "low" | "medium" | "high";  // default: "medium"
+  timeout?: number;  // ms, default: 5000
+};
+```
+
+In `src/mcp/McpTool.ts`, use the server's `riskLevel` instead of hardcoded `"medium"`.
+
+### Configurable Timeout
+
+Pass the server's `timeout` value to `McpClient.connect()`. Use it for both the connection timeout and individual tool call timeouts.
+
+### Auto-Restart
+
+In `src/mcp/client.ts`:
+- Track whether the server process has exited
+- On next `callTool()` after exit, attempt one reconnect (`connect()` again)
+- If reconnect fails, return an error result
+- No infinite restart loops — one attempt only
+
+---
+
+## Delivery
+
+- Single branch `feat/v050-features`
+- One PR with all 4 areas
+- Each gets its own commit(s)
+- `npm run build` and `npm test` must pass

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,7 +12,7 @@ import type { Message } from "../types/message.js";
 import { guessProviderFromModel } from "../providers/index.js";
 import { handleCybergotchiCommand } from "./cybergotchi.js";
 import { connectedMcpServers } from "../mcp/loader.js";
-import { listSessions, loadSession } from "../harness/session.js";
+import { listSessions, loadSession, createSession, saveSession } from "../harness/session.js";
 import { readOhConfig } from "../harness/config.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -180,6 +180,16 @@ register("resume", "Resume a saved session by ID", (args) => {
   } catch {
     return { output: `Session not found: ${id}`, handled: true };
   }
+});
+
+register("fork", "Fork current session (create a branch you can resume later)", (_args, ctx) => {
+  const forked = createSession("", "");
+  forked.messages = [...ctx.messages];
+  saveSession(forked);
+  return {
+    output: `Session forked as ${forked.id}. Resume later with: oh --resume ${forked.id}`,
+    handled: true,
+  };
 });
 
 register("files", "List files in context", (_args, ctx) => {

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -23,30 +23,69 @@ import CybergotchiSetup from "./CybergotchiSetup.js";
 import type { ToolCallState } from "./ToolCallDisplay.js";
 import { cybergotchiEvents } from "../cybergotchi/events.js";
 
+/** Width of the cybergotchi panel (22 content + 2 border + 2 padding + 1 margin) */
+const PANEL_TOTAL_WIDTH = 27;
+/** Minimum terminal width to show the cybergotchi panel */
+const MIN_WIDTH_FOR_PANEL = 60;
+
+function getTerminalWidth(): number {
+  return process.stdout.columns ?? 80;
+}
+
+function getChatWidth(): number {
+  const tw = getTerminalWidth();
+  return tw >= MIN_WIDTH_FOR_PANEL ? tw - PANEL_TOTAL_WIDTH : tw;
+}
+
+/** Truncate a string to fit within maxWidth columns */
+function truncateLine(line: string, maxWidth: number): string {
+  // Strip ANSI codes for length measurement, but keep them in output
+  const stripped = line.replace(/\x1b\[[0-9;]*m/g, '');
+  if (stripped.length <= maxWidth) return line;
+  // Rough truncation — cut at maxWidth chars of visible content
+  let visible = 0;
+  let i = 0;
+  while (i < line.length && visible < maxWidth - 1) {
+    if (line[i] === '\x1b') {
+      const end = line.indexOf('m', i);
+      if (end !== -1) { i = end + 1; continue; }
+    }
+    visible++;
+    i++;
+  }
+  return line.slice(0, i) + '…';
+}
+
 /** Print a finalized message directly to stdout (outside Ink's managed live area). */
 function printMessageToStdout(msg: Message, showDivider: boolean): void {
   if (msg.role === 'tool') return;
 
+  const maxWidth = getChatWidth();
   let out = '';
   if (showDivider) {
-    out += chalk.gray('─'.repeat(60)) + '\n';
+    out += chalk.gray('─'.repeat(Math.min(60, maxWidth))) + '\n';
   }
 
   if (msg.role === 'user') {
-    out += chalk.cyan.bold('❯ ') + chalk.bold(msg.content) + '\n';
+    out += truncateLine(chalk.cyan.bold('❯ ') + chalk.bold(msg.content), maxWidth) + '\n';
   } else if (msg.role === 'assistant') {
     if (msg.content) {
-      out += chalk.magenta.bold('◆ ') + msg.content + '\n';
+      // Truncate each line of assistant content
+      const lines = msg.content.split('\n');
+      const prefix = chalk.magenta.bold('◆ ');
+      out += lines.map((line, i) =>
+        truncateLine(i === 0 ? prefix + line : '  ' + line, maxWidth)
+      ).join('\n') + '\n';
     }
   } else if (msg.role === 'system') {
     if (msg.meta?.isInfo) {
-      out += chalk.gray('  ' + msg.content) + '\n';
+      out += truncateLine(chalk.gray('  ' + msg.content), maxWidth) + '\n';
     } else {
       const inner = '✗ ' + msg.content;
-      const width = inner.length + 2;
-      out += chalk.red('╭' + '─'.repeat(width) + '╮') + '\n';
-      out += chalk.red('│ ' + inner + ' │') + '\n';
-      out += chalk.red('╰' + '─'.repeat(width) + '╯') + '\n';
+      const boxWidth = Math.min(inner.length + 2, maxWidth - 2);
+      out += chalk.red('╭' + '─'.repeat(boxWidth) + '╮') + '\n';
+      out += chalk.red('│ ' + inner.slice(0, boxWidth - 1) + ' │') + '\n';
+      out += chalk.red('╰' + '─'.repeat(boxWidth) + '╯') + '\n';
     }
   }
 
@@ -463,8 +502,8 @@ export default function REPL({
 
   return (
     <Box flexDirection="row">
-      {/* Main chat column */}
-      <Box flexDirection="column" flexGrow={1}>
+      {/* Main chat column — capped to prevent overlap with cybergotchi panel */}
+      <Box flexDirection="column" flexGrow={1} width={getChatWidth()}>
 
         {/* Thinking */}
         {thinkingText && (
@@ -548,8 +587,8 @@ export default function REPL({
         })()}
       </Box>
 
-      {/* Cybergotchi side panel — self-contained, isolated from REPL re-renders */}
-      <CybergotchiPanelConnected />
+      {/* Cybergotchi side panel — hidden when terminal is too narrow */}
+      {getTerminalWidth() >= MIN_WIDTH_FOR_PANEL && <CybergotchiPanelConnected />}
     </Box>
   );
 }

--- a/src/components/REPL.tsx
+++ b/src/components/REPL.tsx
@@ -99,6 +99,7 @@ export default function REPL({
   const [loading, setLoading] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const [streamingText, setStreamingText] = useState("");
+  const [thinkingText, setThinkingText] = useState("");
   const [toolCalls, setToolCalls] = useState<Map<string, ToolCallState>>(new Map());
   const toolCallsRef = useRef(toolCalls);
   toolCallsRef.current = toolCalls;
@@ -188,6 +189,7 @@ export default function REPL({
       abortControllerRef.current = abortController;
       setLoading(true);
       setStreamingText("");
+      setThinkingText("");
       setError(null);
       setToolCalls(new Map());
 
@@ -233,6 +235,10 @@ export default function REPL({
           switch (event.type) {
             case "rate_limited":
               setStreamingText(`⏳ Rate limited — retrying in ${event.retryIn}s… (attempt ${event.attempt}/3)`);
+              break;
+
+            case "thinking_delta":
+              setThinkingText((prev) => prev + event.content);
               break;
 
             case "text_delta":
@@ -337,6 +343,7 @@ export default function REPL({
               break;
 
             case "turn_complete":
+              setThinkingText("");
               if (accumulated) {
                 setMessages((prev) => [...prev, createAssistantMessage(accumulated)]);
               }
@@ -458,6 +465,13 @@ export default function REPL({
     <Box flexDirection="row">
       {/* Main chat column */}
       <Box flexDirection="column" flexGrow={1}>
+
+        {/* Thinking */}
+        {thinkingText && (
+          <Box marginY={0}>
+            <Text dimColor>{"💭 "}{thinkingText.length > 200 ? thinkingText.slice(-200) + "…" : thinkingText}</Text>
+          </Box>
+        )}
 
         {/* Streaming response */}
         {loading && streamingText && (

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -12,6 +12,8 @@ export type McpServerConfig = {
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  riskLevel?: "low" | "medium" | "high";
+  timeout?: number; // ms, default 5000
 };
 
 export type HookDef = {

--- a/src/harness/session.ts
+++ b/src/harness/session.ts
@@ -76,3 +76,9 @@ export function listSessions(dir?: string): Array<{
     .filter((s): s is NonNullable<typeof s> => s !== null)
     .sort((a, b) => b.updatedAt - a.updatedAt);
 }
+
+/** Returns the ID of the most recently updated session, or null if none exist. */
+export function getLastSessionId(dir?: string): string | null {
+  const sessions = listSessions(dir);
+  return sessions.length > 0 ? sessions[0]!.id : null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { PermissionMode } from "./types/permissions.js";
+import type { Message } from "./types/message.js";
 import type { Provider, ProviderConfig } from "./providers/base.js";
 
 const VERSION = "0.5.0";
@@ -169,6 +170,8 @@ program
   .option("--trust", "Auto-approve all tool calls")
   .option("--deny", "Block all non-read tool calls")
   .option("--resume <id>", "Resume a saved session")
+  .option("--continue", "Resume the most recent session")
+  .option("--fork <id>", "Fork (branch) from an existing session")
   .action(async (opts) => {
     // Load saved config as defaults (env vars + CLI flags override)
     const savedConfig = readOhConfig();
@@ -227,13 +230,39 @@ program
     process.on("exit", emitEnd);
     process.on("SIGINT", () => { emitEnd(); process.exit(0); });
 
+    // Session handling
+    let resumeSessionId: string | undefined = opts.resume as string | undefined;
+    let initialMessages: Message[] | undefined;
+
+    if (opts.continue) {
+      const { getLastSessionId } = await import("./harness/session.js");
+      const lastId = getLastSessionId();
+      if (lastId) {
+        resumeSessionId = lastId;
+      } else {
+        console.log("  No previous sessions found.");
+      }
+    }
+
+    if (opts.fork) {
+      const { loadSession } = await import("./harness/session.js");
+      try {
+        const source = loadSession(opts.fork as string);
+        initialMessages = source.messages;
+        console.log(`  Forked from session ${opts.fork} (${source.messages.length} messages)`);
+      } catch {
+        console.log(`  Session ${opts.fork} not found.`);
+      }
+    }
+
     render(
       <App
         provider={provider}
         tools={tools}
         permissionMode={effectivePermMode}
         model={resolvedModel}
-        resumeSessionId={opts.resume as string | undefined}
+        resumeSessionId={resumeSessionId}
+        initialMessages={initialMessages}
       />,
     );
   });

--- a/src/mcp/McpTool.ts
+++ b/src/mcp/McpTool.ts
@@ -8,14 +8,15 @@ export class McpTool implements Tool<z.ZodType> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodType;
-  readonly riskLevel = 'medium' as const;
+  readonly riskLevel: "low" | "medium" | "high";
 
   private client: McpClient;
   private def: McpToolDef;
 
-  constructor(client: McpClient, def: McpToolDef) {
+  constructor(client: McpClient, def: McpToolDef, riskLevel: "low" | "medium" | "high" = "medium") {
     this.client = client;
     this.def = def;
+    this.riskLevel = riskLevel;
     this.name = `${client.name}__${def.name}`;
     this.description = def.description ?? def.name;
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -9,10 +9,15 @@ export class McpClient {
   private nextId = 1;
   private pending = new Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>();
   private ready = false;
+  private dead = false;
+  private cfg: McpServerConfig;
+  private timeoutMs: number;
 
-  private constructor(name: string, proc: ChildProcess) {
+  private constructor(name: string, proc: ChildProcess, cfg: McpServerConfig, timeoutMs: number) {
     this.name = name;
     this.proc = proc;
+    this.cfg = cfg;
+    this.timeoutMs = timeoutMs;
 
     const rl = createInterface({ input: proc.stdout! });
     rl.on('line', (line) => {
@@ -29,6 +34,7 @@ export class McpClient {
     });
 
     proc.on('exit', () => {
+      this.dead = true;
       for (const p of this.pending.values()) {
         p.reject(new Error(`MCP server '${name}' exited`));
       }
@@ -36,13 +42,13 @@ export class McpClient {
     });
   }
 
-  static async connect(cfg: McpServerConfig, timeoutMs = 5_000): Promise<McpClient> {
+  static async connect(cfg: McpServerConfig, timeoutMs = cfg.timeout ?? 5_000): Promise<McpClient> {
     const proc = spawn(cfg.command, cfg.args ?? [], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...(cfg.env ?? {}) },
     });
 
-    const client = new McpClient(cfg.name, proc);
+    const client = new McpClient(cfg.name, proc, cfg, timeoutMs);
 
     // Initialize handshake
     await Promise.race([
@@ -67,6 +73,14 @@ export class McpClient {
   }
 
   async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    if (this.dead) {
+      try {
+        const fresh = await McpClient.connect(this.cfg, this.timeoutMs);
+        Object.assign(this, { proc: fresh.proc, dead: false, ready: true, nextId: 1, pending: new Map() });
+      } catch {
+        throw new Error(`MCP server '${this.name}' died and restart failed`);
+      }
+    }
     const res = await this.call('tools/call', { name, arguments: args });
     if (res.error) throw new Error(res.error.message);
     const content = (res.result as any)?.content ?? [];

--- a/src/mcp/loader.ts
+++ b/src/mcp/loader.ts
@@ -19,7 +19,7 @@ export async function loadMcpTools(): Promise<Tool[]> {
       connectedClients.push(client);
       const defs = await client.listTools();
       for (const def of defs) {
-        tools.push(new McpTool(client, def));
+        tools.push(new McpTool(client, def, server.riskLevel));
       }
     } catch (err) {
       console.warn(`[mcp] Failed to connect to '${server.name}': ${err instanceof Error ? err.message : String(err)}`);

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -103,6 +103,8 @@ export class AnthropicProvider implements Provider {
       messages: this.convertMessages(messages),
       stream: true,
     };
+    // Enable extended thinking for Claude models
+    body.thinking = { type: "enabled", budget_tokens: 10000 };
     const anthropicTools = this.convertTools(tools);
     if (anthropicTools) body.tools = anthropicTools;
 
@@ -135,6 +137,7 @@ export class AnthropicProvider implements Provider {
     let currentToolId = "";
     let currentToolName = "";
     let currentToolArgs = "";
+    let inThinkingBlock = false;
 
     while (true) {
       const { done, value } = await reader.read();
@@ -177,6 +180,9 @@ export class AnthropicProvider implements Provider {
                 callId: block.id,
               };
             }
+            if (block?.type === "thinking") {
+              inThinkingBlock = true;
+            }
             break;
           }
           case "content_block_delta": {
@@ -187,9 +193,13 @@ export class AnthropicProvider implements Provider {
             if (delta?.type === "input_json_delta" && delta.partial_json) {
               currentToolArgs += delta.partial_json;
             }
+            if (delta?.type === "thinking_delta" && delta.thinking) {
+              yield { type: "thinking_delta", content: delta.thinking };
+            }
             break;
           }
           case "content_block_stop": {
+            inThinkingBlock = false;
             if (currentToolId) {
               yield {
                 type: "tool_call_complete",

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -112,6 +112,8 @@ export class OllamaProvider implements Provider {
 
     const decoder = new TextDecoder();
     let buffer = "";
+    let inThinkBlock = false;
+    let thinkBuffer = "";
 
     while (true) {
       const { done, value } = await reader.read();
@@ -137,7 +139,37 @@ export class OllamaProvider implements Provider {
         }
 
         if (chunk.message?.content) {
-          yield { type: "text_delta", content: chunk.message.content };
+          // Parse <think> tags — yield thinking_delta for think blocks, text_delta for normal text
+          let remaining = chunk.message.content;
+          while (remaining.length > 0) {
+            if (inThinkBlock) {
+              const closeIdx = remaining.indexOf("</think>");
+              if (closeIdx !== -1) {
+                thinkBuffer += remaining.slice(0, closeIdx);
+                if (thinkBuffer) {
+                  yield { type: "thinking_delta" as const, content: thinkBuffer };
+                }
+                thinkBuffer = "";
+                inThinkBlock = false;
+                remaining = remaining.slice(closeIdx + "</think>".length);
+              } else {
+                thinkBuffer += remaining;
+                remaining = "";
+              }
+            } else {
+              const openIdx = remaining.indexOf("<think>");
+              if (openIdx !== -1) {
+                if (openIdx > 0) {
+                  yield { type: "text_delta", content: remaining.slice(0, openIdx) };
+                }
+                inThinkBlock = true;
+                remaining = remaining.slice(openIdx + "<think>".length);
+              } else {
+                yield { type: "text_delta", content: remaining };
+                remaining = "";
+              }
+            }
+          }
         }
 
         if (chunk.message?.tool_calls) {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -89,6 +89,11 @@ export class OpenAIProvider implements Provider {
     };
     if (tools?.length) body.tools = tools;
 
+    // Enable reasoning for o-series models
+    if (m.startsWith("o1") || m.startsWith("o3")) {
+      body.reasoning_effort = "medium";
+    }
+
     let res: Response;
     try {
       res = await fetch(`${this.baseUrl}/chat/completions`, {
@@ -155,6 +160,10 @@ export class OpenAIProvider implements Provider {
 
         if (delta.content) {
           yield { type: "text_delta", content: delta.content };
+        }
+
+        if (delta.reasoning_content) {
+          yield { type: "thinking_delta" as const, content: delta.reasoning_content };
         }
 
         if (delta.tool_calls) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -60,6 +60,11 @@ export type RateLimited = {
   readonly attempt: number;   // 1-based
 };
 
+export type ThinkingDelta = {
+  readonly type: "thinking_delta";
+  readonly content: string;
+};
+
 export type ToolOutputDelta = {
   readonly type: "tool_output_delta";
   readonly callId: string;
@@ -84,4 +89,5 @@ export type StreamEvent =
   | CostUpdate
   | TurnComplete
   | ErrorEvent
-  | RateLimited;
+  | RateLimited
+  | ThinkingDelta;


### PR DESCRIPTION
## Summary

The cybergotchi ASCII art panel was rendering on top of chat content (reported as 宠物干扰文本 — pet interferes with text).

**Root cause:** Two rendering layers collide — stdout-printed messages render at full terminal width, and Ink's left column has no width constraint. Both extend into the right 27 columns where the panel lives.

**Fix:**
- stdout messages now truncate to `terminalWidth - 27` columns
- Ink left column gets explicit `width={getChatWidth()}`
- Panel auto-hides when terminal < 60 columns

## Test plan
- [x] Send a message that generates a long code block — text stays left of the panel
- [x] Resize terminal to < 60 columns — panel hides, chat uses full width
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)