### PR TITLE
feat: external plugin/skill/agent format interop

### DIFF
--- a/.github/actions/review/action.yml
+++ b/.github/actions/review/action.yml
@@ -78,11 +78,30 @@ runs:
         $(cat /tmp/pr-diff.txt)
         \`\`\`"
 
-        openharness run -m "${{ inputs.model }}" \
+        # Hard ceiling of 10 min on the openharness call itself (exit 124 on timeout).
+        # --max-turns 10 prevents a runaway agent loop; --permission-mode deny already
+        # blocks tools, but we've seen the model retry indefinitely in some configs.
+        set +e
+        timeout 600 openharness run -m "${{ inputs.model }}" \
           --permission-mode "${{ inputs.permission_mode }}" \
           --output-format text \
-          "$REVIEW_PROMPT" > /tmp/review-output.txt 2>/tmp/review-errors.txt || true
+          --max-turns 10 \
+          "$REVIEW_PROMPT" > /tmp/review-output.txt 2>/tmp/review-errors.txt
+        REVIEW_EXIT=$?
+        set -e
 
+        echo "=== openharness exit code: $REVIEW_EXIT ==="
+        if [ "$REVIEW_EXIT" = "124" ]; then
+          echo "⚠ openharness run timed out after 600s" | tee -a /tmp/review-output.txt
+        fi
+        if [ -s /tmp/review-errors.txt ]; then
+          echo "=== openharness stderr ==="
+          cat /tmp/review-errors.txt
+          echo "=== end stderr ==="
+        fi
+
+        # Emit the review text to step outputs regardless of exit code — comment step
+        # will post whatever we got (or skip if empty).
         echo "review<<EOF" >> $GITHUB_OUTPUT
         cat /tmp/review-output.txt >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/actions/review/action.yml
+++ b/.github/actions/review/action.yml
@@ -1,5 +1,5 @@
 name: 'OpenHarness Code Review'
-description: 'AI-powered code review using OpenHarness CLI'
+description: 'AI-powered code review using OpenHarness CLI. Advisory — posts a PR comment.'
 branding:
   icon: 'code'
   color: 'purple'
@@ -20,19 +20,26 @@ inputs:
     required: false
     default: 'deny'
   max_diff_size:
-    description: 'Max diff size in characters to include in review prompt'
+    description: 'Max diff size in characters to include in the review prompt'
     required: false
     default: '50000'
   custom_prompt:
     description: 'Additional instructions to append to the review prompt'
     required: false
     default: ''
+  pr_number:
+    description: 'PR number (when triggered from issue_comment — GITHUB_REF is not the PR)'
+    required: false
+  base_sha:
+    description: 'Base SHA to diff against'
+    required: false
+  head_sha:
+    description: 'Head SHA to review'
+    required: false
 
 outputs:
   review:
     description: 'The review output text'
-  exit_code:
-    description: 'Exit code (0 = pass, 1 = issues found)'
 
 runs:
   using: 'composite'
@@ -46,19 +53,51 @@ runs:
       shell: bash
       run: npm install -g @zhijiewang/openharness
 
-    - name: Get PR diff
-      id: diff
+    - name: Build prompt (safe — no shell interpolation of PR content)
+      id: build-prompt
       shell: bash
+      env:
+        # Route PR metadata through env vars so GitHub Actions never injects user-controlled
+        # content into a shell-quoted string. $(...), backticks, and $VAR in the body are
+        # treated as literal text.
+        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        PR_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+        PR_BODY: ${{ github.event.pull_request.body || github.event.issue.body }}
+        BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+        CUSTOM_PROMPT: ${{ inputs.custom_prompt }}
+        MAX_DIFF_SIZE: ${{ inputs.max_diff_size }}
       run: |
-        # Get the diff between base and head
-        git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > /tmp/pr-diff.txt
+        set -euo pipefail
+
+        # 1) Capture diff safely to a file.
+        git diff "$BASE_SHA".."$HEAD_SHA" > /tmp/pr-diff.txt
         DIFF_SIZE=$(wc -c < /tmp/pr-diff.txt)
-        MAX_SIZE=${{ inputs.max_diff_size }}
-        if [ "$DIFF_SIZE" -gt "$MAX_SIZE" ]; then
-          head -c $MAX_SIZE /tmp/pr-diff.txt > /tmp/pr-diff-trimmed.txt
-          echo "... [diff truncated at ${MAX_SIZE} chars]" >> /tmp/pr-diff-trimmed.txt
+        if [ "$DIFF_SIZE" -gt "$MAX_DIFF_SIZE" ]; then
+          head -c "$MAX_DIFF_SIZE" /tmp/pr-diff.txt > /tmp/pr-diff-trimmed.txt
+          printf '\n... [diff truncated at %s chars]\n' "$MAX_DIFF_SIZE" >> /tmp/pr-diff-trimmed.txt
           mv /tmp/pr-diff-trimmed.txt /tmp/pr-diff.txt
         fi
+
+        # 2) Build prompt by writing literal text + env-var values via printf.
+        # printf %s prints the arg VERBATIM — no expansion of $(...), backticks, or $VAR
+        # inside the value. This is what protects against shell injection via PR content.
+        {
+          printf '%s\n' "Review this pull request diff for bugs, security issues, code quality, and correctness. Be specific about line numbers and file paths. If everything looks good, say so briefly."
+          printf '\n'
+          printf 'PR #%s: %s\n' "$PR_NUMBER" "$PR_TITLE"
+          printf '\nPR Body:\n'
+          printf '%s\n' "$PR_BODY"
+          printf '\n'
+          if [ -n "$CUSTOM_PROMPT" ]; then
+            printf '%s\n\n' "$CUSTOM_PROMPT"
+          fi
+          printf '```diff\n'
+          cat /tmp/pr-diff.txt
+          printf '\n```\n'
+        } > /tmp/review-prompt.txt
+
+        printf 'Prompt size: %s bytes\n' "$(wc -c < /tmp/review-prompt.txt)"
 
     - name: Run review
       id: review
@@ -67,26 +106,16 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
       run: |
-        REVIEW_PROMPT="Review this pull request diff for bugs, security issues, code quality, and correctness. Be specific about line numbers and file paths. If everything looks good, say so briefly.
-
-        PR Title: ${{ github.event.pull_request.title }}
-        PR Body: ${{ github.event.pull_request.body }}
-
-        ${{ inputs.custom_prompt }}
-
-        \`\`\`diff
-        $(cat /tmp/pr-diff.txt)
-        \`\`\`"
-
-        # Hard ceiling of 10 min on the openharness call itself (exit 124 on timeout).
-        # --max-turns 10 prevents a runaway agent loop; --permission-mode deny already
-        # blocks tools, but we've seen the model retry indefinitely in some configs.
+        # Pipe prompt via stdin (openharness run supports `-` to read from stdin). Using
+        # stdin sidesteps every shell-quoting pitfall that plagued the prior version.
+        # `timeout 600` bounds the model call; `--max-turns 10` bounds the agent loop.
         set +e
-        timeout 600 openharness run -m "${{ inputs.model }}" \
+        timeout 600 openharness run \
+          -m "${{ inputs.model }}" \
           --permission-mode "${{ inputs.permission_mode }}" \
           --output-format text \
           --max-turns 10 \
-          "$REVIEW_PROMPT" > /tmp/review-output.txt 2>/tmp/review-errors.txt
+          - < /tmp/review-prompt.txt > /tmp/review-output.txt 2>/tmp/review-errors.txt
         REVIEW_EXIT=$?
         set -e
 
@@ -100,23 +129,26 @@ runs:
           echo "=== end stderr ==="
         fi
 
-        # Emit the review text to step outputs regardless of exit code — comment step
-        # will post whatever we got (or skip if empty).
-        echo "review<<EOF" >> $GITHUB_OUTPUT
-        cat /tmp/review-output.txt >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+        {
+          echo "review<<REVIEW_EOF"
+          cat /tmp/review-output.txt
+          echo "REVIEW_EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Post review comment
-      if: github.event_name == 'pull_request'
+      if: steps.review.outputs.review != ''
       uses: actions/github-script@v7
+      env:
+        REVIEW_BODY: ${{ steps.review.outputs.review }}
+        MODEL: ${{ inputs.model }}
+        PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
       with:
         script: |
-          const review = `${{ steps.review.outputs.review }}`;
-          if (review.trim()) {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `## 🤖 OpenHarness Code Review\n\n${review}\n\n---\n*Reviewed by [OpenHarness](https://github.com/zhijiewang/openCLI) with model \`${{ inputs.model }}\`*`
-            });
-          }
+          const { REVIEW_BODY, MODEL, PR_NUMBER } = process.env;
+          if (!REVIEW_BODY || !REVIEW_BODY.trim()) return;
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: Number(PR_NUMBER),
+            body: `## 🤖 OpenHarness Code Review\n\n${REVIEW_BODY}\n\n---\n*Advisory review by [OpenHarness](https://github.com/zhijiewong/openharness) using model \`${MODEL}\`. Findings are informational; the author decides what to do.*`,
+          });

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,8 +1,11 @@
 name: AI Code Review
 
+# Manually triggered only — comment `@openharness` or `/oh-review` on a PR to run.
+# This mirrors anthropics/claude-code (@claude) and sst/opencode (/review): opt-in,
+# advisory, so a broken OH version cannot block its own PRs.
 on:
-  pull_request:
-    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -10,19 +13,41 @@ permissions:
 
 jobs:
   review:
+    # Only run on PR comments (not issue comments) that mention the magic word
+    # from a user with push access (author_association filters drive-by invocations).
+    if: |
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '@openharness') || contains(github.event.comment.body, '/oh-review')) &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
-    # Fail-fast if the review action hangs — default job timeout is 6 hours, which
-    # burns runner minutes and blocks PR merges when the LLM call doesn't return.
+    # Hard ceiling — the runner kills everything after 15 min regardless of what the
+    # action does.
     timeout-minutes: 15
-    # Only run if ANTHROPIC_API_KEY is configured in repo secrets
-    if: github.event.pull_request.draft == false
     steps:
+      - name: Resolve PR head ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          BASE_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.base.sha')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Full history for diff
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
 
       - uses: ./.github/actions/review
         with:
           model: 'claude-sonnet-4-6'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          permission_mode: 'deny'  # Read-only review, no file modifications
+          permission_mode: 'deny'
+          pr_number: ${{ steps.pr.outputs.number }}
+          base_sha: ${{ steps.pr.outputs.base_sha }}
+          head_sha: ${{ steps.pr.outputs.head_sha }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Fail-fast if the review action hangs — default job timeout is 6 hours, which
+    # burns runner minutes and blocks PR merges when the LLM call doesn't return.
+    timeout-minutes: 15
     # Only run if ANTHROPIC_API_KEY is configured in repo secrets
     if: github.event.pull_request.draft == false
     steps:

--- a/data/registry.json
+++ b/data/registry.json
@@ -6,7 +6,10 @@
       "author": "zhijiewong",
       "version": "1.0.0",
       "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/code-review.md",
-      "tags": ["review", "quality", "security"]
+      "tags": ["review", "quality", "security"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
     },
     {
       "name": "debug",
@@ -14,7 +17,10 @@
       "author": "zhijiewong",
       "version": "1.0.0",
       "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/debug.md",
-      "tags": ["debug", "fix", "troubleshoot"]
+      "tags": ["debug", "fix", "troubleshoot"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
     },
     {
       "name": "tdd",
@@ -22,7 +28,10 @@
       "author": "zhijiewong",
       "version": "1.0.0",
       "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/tdd.md",
-      "tags": ["test", "tdd", "testing"]
+      "tags": ["test", "tdd", "testing"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
     },
     {
       "name": "commit",
@@ -30,7 +39,224 @@
       "author": "zhijiewong",
       "version": "1.0.0",
       "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/commit.md",
-      "tags": ["git", "commit", "version-control"]
+      "tags": ["git", "commit", "version-control"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
+    },
+    {
+      "name": "diagnose",
+      "description": "Diagnose why an agent run failed, regressed, or produced unexpected output",
+      "author": "zhijiewong",
+      "version": "1.0.0",
+      "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/diagnose.md",
+      "tags": ["agent", "debug", "diagnose", "ops"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
+    },
+    {
+      "name": "plan",
+      "description": "Design an implementation plan before coding",
+      "author": "zhijiewong",
+      "version": "1.0.0",
+      "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/plan.md",
+      "tags": ["plan", "design", "architecture"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
+    },
+    {
+      "name": "simplify",
+      "description": "Refactor code to be simpler and more maintainable without changing behavior",
+      "author": "zhijiewong",
+      "version": "1.0.0",
+      "source": "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/skills/simplify.md",
+      "tags": ["refactor", "simplify", "quality"],
+      "license": "MIT",
+      "attribution": "© 2025 OpenHarness contributors",
+      "upstream": "https://github.com/zhijiewong/openharness"
+    },
+
+    {
+      "name": "superpowers-brainstorming",
+      "description": "Explores user intent, requirements and design before implementation. Use before any creative work.",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/brainstorming/SKILL.md",
+      "tags": ["plan", "brainstorm", "design", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-systematic-debugging",
+      "description": "Structured debugging approach before proposing fixes",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/systematic-debugging/SKILL.md",
+      "tags": ["debug", "fix", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-test-driven-development",
+      "description": "Strict TDD workflow — test first, minimal implementation, refactor",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/test-driven-development/SKILL.md",
+      "tags": ["test", "tdd", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-writing-plans",
+      "description": "Author detailed implementation plans for multi-step tasks before touching code",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/writing-plans/SKILL.md",
+      "tags": ["plan", "write", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-executing-plans",
+      "description": "Execute a written implementation plan with review checkpoints",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/executing-plans/SKILL.md",
+      "tags": ["execute", "plan", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-using-git-worktrees",
+      "description": "Create isolated git worktrees for feature development with safety verification",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/using-git-worktrees/SKILL.md",
+      "tags": ["git", "worktree", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-verification-before-completion",
+      "description": "Run verification commands and confirm output before claiming work is complete",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/verification-before-completion/SKILL.md",
+      "tags": ["verify", "complete", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "superpowers-dispatching-parallel-agents",
+      "description": "Dispatch multiple independent tasks to parallel sub-agents",
+      "author": "Jesse Vincent",
+      "version": "5.0.7",
+      "source": "https://raw.githubusercontent.com/obra/superpowers/main/skills/dispatching-parallel-agents/SKILL.md",
+      "tags": ["parallel", "agent", "superpowers"],
+      "license": "MIT",
+      "attribution": "© 2025 Jesse Vincent — superpowers plugin",
+      "upstream": "https://github.com/obra/superpowers"
+    },
+
+    {
+      "name": "cli-anything-shotcut",
+      "description": "CLI for Shotcut — stateful video editing via MLT XML, designed for agents",
+      "author": "HKUDS",
+      "version": "0.1.0",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/shotcut/agent-harness/cli_anything/shotcut/skills/SKILL.md",
+      "tags": ["video", "editing", "shotcut", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+    {
+      "name": "cli-anything-obsidian",
+      "description": "CLI for Obsidian via the Local REST API — knowledge management harness",
+      "author": "HKUDS",
+      "version": "0.1.0",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md",
+      "tags": ["obsidian", "notes", "kb", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+    {
+      "name": "cli-anything-zotero",
+      "description": "CLI for Zotero — reference management automation",
+      "author": "HKUDS",
+      "version": "0.4.1",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/zotero/agent-harness/cli_anything/zotero/skills/SKILL.md",
+      "tags": ["zotero", "research", "references", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+    {
+      "name": "cli-anything-blender",
+      "description": "CLI for Blender — 3D modeling automation",
+      "author": "HKUDS",
+      "version": "0.1.0",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/blender/agent-harness/cli_anything/blender/skills/SKILL.md",
+      "tags": ["blender", "3d", "modeling", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+    {
+      "name": "cli-anything-inkscape",
+      "description": "CLI for Inkscape — vector graphics automation",
+      "author": "HKUDS",
+      "version": "0.1.0",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/inkscape/agent-harness/cli_anything/inkscape/skills/SKILL.md",
+      "tags": ["inkscape", "svg", "vector", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+    {
+      "name": "cli-anything-godot",
+      "description": "CLI for Godot — game engine automation with E2E demo pipeline",
+      "author": "HKUDS",
+      "version": "0.1.0",
+      "source": "https://raw.githubusercontent.com/HKUDS/CLI-Anything/main/godot/agent-harness/cli_anything/godot/skills/SKILL.md",
+      "tags": ["godot", "game", "engine", "cli-anything"],
+      "license": "Apache-2.0",
+      "attribution": "© HKUDS CLI-Anything contributors",
+      "upstream": "https://github.com/HKUDS/CLI-Anything"
+    },
+
+    {
+      "name": "tob-smart-contract-audit",
+      "description": "Trail of Bits — smart contract security audit workflow (link-only, CC-BY-SA)",
+      "author": "Trail of Bits",
+      "version": "1.0.0",
+      "source": "https://raw.githubusercontent.com/trailofbits/skills/main/skills/smart-contract-audit/SKILL.md",
+      "tags": ["security", "audit", "smart-contract", "tob"],
+      "license": "CC-BY-SA-4.0",
+      "attribution": "© Trail of Bits — CC-BY-SA-4.0 (ShareAlike)",
+      "upstream": "https://github.com/trailofbits/skills",
+      "installable": false
+    },
+    {
+      "name": "tob-malware-detection",
+      "description": "Trail of Bits — malware detection workflow (link-only, CC-BY-SA)",
+      "author": "Trail of Bits",
+      "version": "1.0.0",
+      "source": "https://raw.githubusercontent.com/trailofbits/skills/main/skills/malware-detection/SKILL.md",
+      "tags": ["security", "malware", "detection", "tob"],
+      "license": "CC-BY-SA-4.0",
+      "attribution": "© Trail of Bits — CC-BY-SA-4.0 (ShareAlike)",
+      "upstream": "https://github.com/trailofbits/skills",
+      "installable": false
     }
   ]
 }

--- a/data/skills/diagnose.md
+++ b/data/skills/diagnose.md
@@ -1,0 +1,24 @@
+---
+name: diagnose
+description: Diagnose why an agent run failed, regressed, or produced unexpected output — using structured evidence instead of intuition
+whenToUse: When an agent run produced wrong output, crashed mid-execution, or regressed from a previous successful run
+allowedTools: [Read, Bash, Grep, Glob]
+---
+
+# Diagnose Agent Run
+
+Apply this when something an agent did went wrong — not for ordinary code bugs (use `debug` for those).
+
+1. **Define the failure precisely** — What was the expected output? What was the actual output? One sentence each.
+2. **Locate the artifacts** — Find the run's logs, transcripts, tool-call traces, and any files it produced. Common locations: `.oh/logs/`, `.oh/tasks.json`, `.oh/sessions/`, stderr capture.
+3. **Reconstruct the timeline** — Walk through tool calls in order. Where did the trajectory diverge from what should have happened?
+4. **Isolate the inflection point** — Find the single tool call, prompt step, or input that turned a working run into a broken one.
+5. **Form a hypothesis** — Was it bad input, model regression, missing context, tool timeout, permission denial, or stale memory? Be specific.
+6. **Verify with a minimal repro** — Re-run only the inflection step in isolation. Confirm the same wrong behavior reproduces.
+7. **Report** — Write up: failure mode, inflection point (file:line or message index), root cause, suggested fix.
+
+Rules:
+- Don't guess from the symptom. Read the actual logs.
+- Distinguish "the model made a bad decision" from "the harness broke" — they need different fixes.
+- If the run is non-deterministic, repro at least 3 times before claiming a hypothesis.
+- Never edit code as part of diagnosis. The output is a report, not a fix.

--- a/data/skills/plan.md
+++ b/data/skills/plan.md
@@ -1,0 +1,25 @@
+---
+name: plan
+description: Design an implementation plan before coding
+whenToUse: When the user asks to build a feature, fix a non-trivial bug, or refactor — anything beyond a one-line change
+allowedTools: [Read, Glob, Grep]
+---
+
+# Implementation Planning
+
+Plan before you code. The output is a written plan, not edited files.
+
+1. **Restate the goal** — One sentence describing what success looks like. Confirm with the user if ambiguous.
+2. **Map the affected surface** — List every file you'll touch and every public interface you'll change.
+3. **Find existing patterns** — Search the codebase for similar features. Reuse existing utilities; don't invent parallel ones.
+4. **Identify the minimal change** — What's the smallest set of edits that delivers the goal? Resist scope creep.
+5. **Sequence the work** — Order the changes so each step is independently testable. Each step should leave the build green.
+6. **Plan verification** — How will you know each step worked? List the commands or manual checks.
+7. **Surface risks** — What could go wrong? Migration data loss, breaking changes, perf regression, security holes? Note each with a mitigation.
+8. **Write it up** — A short doc with: goal, files touched, sequence, verification, risks. Get user approval before coding.
+
+Rules:
+- Don't write code in this phase. Only research and write the plan.
+- A plan that lists "all the things" is not a plan. Pick the recommended approach.
+- Cite files and functions you'll reuse with `path:line` references.
+- If you can't write the plan in one page, the scope is too big — split it.

--- a/data/skills/simplify.md
+++ b/data/skills/simplify.md
@@ -1,0 +1,24 @@
+---
+name: simplify
+description: Refactor code to be simpler and more maintainable without changing behavior
+whenToUse: When code is hard to read, has duplicated logic, over-abstracts, or accumulated dead branches
+allowedTools: [Read, Edit, Bash, Glob, Grep]
+---
+
+# Simplify Code
+
+Simpler code is easier to read, change, and debug. Behavior must not change.
+
+1. **Read the code in scope** — Understand what it does end-to-end before touching anything.
+2. **List the smells** — Duplication, dead branches, premature abstraction, deeply nested conditionals, vague names, comments that explain WHAT instead of WHY.
+3. **Confirm tests cover the behavior** — If there are no tests, write characterization tests first. Refactoring without tests is gambling.
+4. **Make one change at a time** — Inline a wrapper, extract a function, rename a variable, delete dead code. Run tests after each.
+5. **Prefer deletion over addition** — If you can remove code without breaking tests, that's almost always the right move.
+6. **Stop when it's good enough** — Don't refactor for its own sake. Stop when further changes wouldn't meaningfully improve readability.
+
+Rules:
+- Never change behavior. If you discover a bug, file it separately — don't fix it during a refactor.
+- Three similar lines is better than a premature abstraction. Wait until the third or fourth occurrence before extracting.
+- Delete comments that explain what well-named code already says.
+- If the change touches more than one file or one concern, split it into separate refactors.
+- Don't introduce new dependencies, frameworks, or patterns.

--- a/docs/ecosystem-compat.md
+++ b/docs/ecosystem-compat.md
@@ -1,0 +1,119 @@
+# Claude Code Ecosystem Compatibility
+
+This document tracks what Claude Code conventions OpenHarness supports, where they diverge, and what's deferred. If you've built a plugin or skill for Claude Code, this is the page that tells you whether it will work in OpenHarness today.
+
+Scope of this document: the published Anthropic spec at <https://agentskills.io/specification> and the Claude Code CLI docs at <https://code.claude.com/docs/en/>. Commit refs point to the OH commit that introduced each capability.
+
+## Quick status
+
+| Area | Status | Notes |
+|---|---|---|
+| Skill frontmatter (Anthropic kebab-case) | ✅ | Aliases for `allowed-tools`, `disable-model-invocation`, `argument-hint`, `when-to-use` |
+| Skill `license` + `paths` fields | ✅ parsed | `paths` glob-scoped auto-surfacing is stored but not yet enforced at prompt time |
+| Directory-packaged skills (`skill-name/SKILL.md`) | ✅ | Companion `.md` files inside the directory do not register as separate skills |
+| `.claude/skills/` + `.claude/agents/` discovery | ✅ | Read alongside `.oh/skills/` and `.oh/agents/` |
+| `.claude-plugin/plugin.json` manifest | ✅ | Auto-discovered from `~/.oh/plugins/cache/` even without `installed.json` entry |
+| `.claude-plugin/marketplace.json` | ✅ | `addMarketplace` probes both OH-native and CC paths; source-typed entries (`github`, `npm`, `url`) are converted to OH's internal format |
+| Plugin-shipped `.mcp.json` | ✅ discovered | Runtime injection into the MCP client is deferred (Phase 6) |
+| Plugin-shipped `hooks/hooks.json` | ✅ discovered | Runtime registration with the hooks subsystem is deferred (Phase 6) |
+| Plugin-shipped `.lsp.json` | ✅ discovered | Runtime wiring deferred |
+| Sub-agent markdown (`.claude/agents/*.md`) | ✅ | Fields: `name`, `description`, `tools`, `disallowedTools`, `model`, `isolation`, `mcpServers` (inline JSON), `hooks` (inline JSON) |
+| Skill `context: fork` + `agent` fields | ✅ parsed | Dispatcher wiring (actual sub-agent spawn from skill) deferred |
+| Permission enforcement in `oh mcp-server` | ⚠️ intentional | `toolPermissions` is NOT enforced when exposing tools via stdio — use `oh remote` if callers are less trusted |
+| License gate on `/skill-install` | ✅ | Non-permissive SPDX licenses require `--accept-license=<id>`; `installable: false` entries are link-only |
+
+## Field-by-field alias table (skills)
+
+OH parses both forms. Both are interchangeable.
+
+| Anthropic spec | OH legacy | Notes |
+|---|---|---|
+| `name` | `name` | required |
+| `description` | `description` | required |
+| `allowed-tools: Read Glob` | `allowedTools: [Read, Glob]` | Both accepted, merged |
+| `disable-model-invocation: true` | `invokeModel: false` | Equivalent |
+| `argument-hint: [--prod]` | `args: [--prod]` | Equivalent |
+| `when-to-use: …` | (none) | New field; appended to description for future trigger matching |
+| `license: MIT` | (none) | Used by the install gate |
+| `paths: [src/**/*.ts]` | (none) | Stored; not yet used for auto-surfacing filtering |
+| `context: fork` | (none) | Stored; dispatcher wiring deferred |
+| `agent: code-reviewer` | (none) | Stored; dispatcher wiring deferred |
+
+## Field-by-field alias table (agents)
+
+| Anthropic spec | OH | Notes |
+|---|---|---|
+| `tools: Read Glob Grep` | `tools: [Read, Glob, Grep]` | Both accepted (space OR comma separated OR YAML array) |
+| `disallowedTools: Write` | — | New field |
+| `disallowed-tools: Write` | — | kebab alias also accepted |
+| `model: sonnet` | — | New field |
+| `isolation: worktree` | — | Explicit opt-in. Legacy OH auto-creates a worktree when in a git repo; explicit `isolation: worktree` is preferred |
+| `mcpServers: {...}` | — | Inline JSON in YAML frontmatter |
+| `hooks: {...}` | — | Inline JSON in YAML frontmatter |
+
+## Marketplace source types
+
+| Anthropic `source` form | Supported? | How OH resolves it |
+|---|---|---|
+| `./relative/path` | ❌ | Relative paths assume the marketplace repo is cloned locally; OH doesn't maintain that state |
+| `{source: "github", repo, ref}` | ✅ | Converted to OH `{type: "github", repo}`; `ref` currently dropped |
+| `{source: "url", url}` | ✅ | Converted to OH `{type: "url", url}` |
+| `{source: "npm", package, version}` | ✅ | Converted to OH `{type: "npm", package}`; `version` dropped |
+
+## Directory layout OH accepts for a plugin
+
+```
+<plugin-root>/
+├── .claude-plugin/
+│   └── plugin.json             ← manifest (required)
+├── skills/
+│   ├── flat-skill.md           ← OH-legacy flat layout
+│   └── directory-skill/
+│       ├── SKILL.md            ← Anthropic-style directory package
+│       ├── reference.md        ← companion docs (read on demand, not a separate skill)
+│       └── scripts/…           ← executable assets (not parsed)
+├── agents/
+│   ├── my-agent.md             ← subagent (Markdown + YAML frontmatter)
+│   └── ...
+├── .mcp.json                   ← MCP servers (discovered via getPluginMcpServers)
+├── hooks/
+│   └── hooks.json              ← hooks config (discovered via getPluginHooks)
+└── .lsp.json                   ← LSP servers (discovered via getPluginLspServers)
+```
+
+Drop this layout anywhere under `~/.oh/plugins/cache/<name>/<version>/` and OH will surface it automatically — no entry in `installed.json` required. This means a Claude Code plugin `git clone`'d into the cache dir works without a registration step.
+
+## What does NOT work (known gaps)
+
+These items are parsed/discovered but not wired to OH's runtime yet. Track them in future sessions or PRs:
+
+1. **AgentDispatcher per-agent MCP/hook injection.** Agent-level `mcpServers` and `hooks` fields are parsed and exposed on the `AgentRole` type, but `AgentDispatcher` doesn't filter the MCP server list or hook registrations per agent at dispatch time. Calling a sub-agent gets the full top-level config today.
+2. **Skill `context: fork` execution.** The field is parsed, but the Skill tool doesn't currently spawn a sub-agent context when it encounters `context: fork` in a skill's frontmatter. The skill body executes in the parent agent's context.
+3. **LSP plugin runtime wiring.** `.lsp.json` is discovered but not merged into OH's LSP client configuration.
+4. **`paths:` glob auto-surfacing filter.** The field is stored on `SkillMetadata`; `findTriggeredSkills` doesn't yet consult it to scope which skill appears based on the file currently in scope.
+5. **Anthropic proprietary skills.** `anthropics/skills` is proprietary (see its LICENSE.txt) and cannot be redistributed. OH's registry does not list it. If you want those skills, install them through Anthropic's own distribution channel.
+
+## License policy for installing
+
+OH's `/skill-install` gate uses this SPDX allowlist:
+
+```
+MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, CC0-1.0, Unlicense
+```
+
+Anything outside the list requires `--accept-license=<SPDX>` to acknowledge the terms. `installable: false` registry entries are link-only (the user must install from upstream under the license's terms) — used today for CC-BY-SA (viral) content.
+
+## Commit trail
+
+| Session | Commit | Scope |
+|---|---|---|
+| 1 | `67cc1aa` | Skill format aliases, license gate, bundled-skill loading, /skills command, 3 OH-native skills, registry expanded 4→23 |
+| 2 | `d47ddea` | Directory-packaged skills, .claude-plugin/plugin.json manifest discovery, /plugin alias + info subcommand |
+| 3 | `d7447da` | AgentRole model/disallowedTools/isolation, .claude/agents/ discovery, .claude-plugin/marketplace.json parser, getPluginMcpServers/getPluginHooks |
+| 4 | (this) | Skill context/agent fields, getPluginLspServers, AgentRole mcpServers/hooks parsing, CC-plugin integration test, this doc |
+
+## Related docs
+
+- [plugins.md](./plugins.md) — writing an OH-native plugin
+- [mcp-servers.md](./mcp-servers.md) — configuring MCP servers in OH
+- [agent-roles.md](./agent-roles.md) — building sub-agents

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "dist/**/*.d.ts",
     "!dist/**/*.test.*",
     "!dist/**/test-helpers.*",
+    "data/skills/**/*.md",
+    "data/registry.json",
     "README.md",
     "LICENSE"
   ],

--- a/src/agents/roles.test.ts
+++ b/src/agents/roles.test.ts
@@ -151,4 +151,29 @@ describe("agent roles", () => {
       assert.equal(agents[0]!.name, "From OH");
     });
   });
+
+  it("parses inline-JSON mcpServers + hooks fields", () => {
+    withTmpCwd((dir) => {
+      writeFile(
+        dir,
+        ".oh/agents/with-mcp.md",
+        `---\nname: WithMcp\ndescription: x\nmcpServers: {"excel":{"command":"npx"}}\nhooks: {"PreToolUse":[{"command":"echo pre"}]}\n---\nbody\n`,
+      );
+      const a = discoverMarkdownAgents().find((r) => r.id === "with-mcp");
+      assert.ok(a);
+      assert.ok(a!.mcpServers);
+      assert.ok("excel" in (a!.mcpServers as object));
+      assert.ok(a!.hooks);
+      assert.ok("PreToolUse" in (a!.hooks as object));
+    });
+  });
+
+  it("silently ignores malformed JSON in mcpServers/hooks", () => {
+    withTmpCwd((dir) => {
+      writeFile(dir, ".oh/agents/bad-json.md", `---\nname: BadJson\ndescription: x\nmcpServers: {not json}\n---\n`);
+      const a = discoverMarkdownAgents().find((r) => r.id === "bad-json");
+      assert.ok(a);
+      assert.equal(a!.mcpServers, undefined);
+    });
+  });
 });

--- a/src/agents/roles.test.ts
+++ b/src/agents/roles.test.ts
@@ -1,6 +1,18 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { getRole, getRoleIds, listRoles } from "./roles.js";
+import { makeTmpDir, writeFile } from "../test-helpers.js";
+import { discoverMarkdownAgents, getRole, getRoleIds, listRoles } from "./roles.js";
+
+function withTmpCwd(fn: (dir: string) => void) {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    fn(dir);
+  } finally {
+    process.chdir(original);
+  }
+}
 
 describe("agent roles", () => {
   it("lists all roles", () => {
@@ -69,5 +81,74 @@ describe("agent roles", () => {
         );
       }
     }
+  });
+
+  // ── Claude Code interop ──
+
+  it("parses tools as space-separated string (Claude Code style)", () => {
+    withTmpCwd((dir) => {
+      writeFile(
+        dir,
+        ".oh/agents/cc-style.md",
+        `---\nname: CC Style\ndescription: x\ntools: Read Glob Grep\n---\nbody\n`,
+      );
+      const agents = discoverMarkdownAgents();
+      const a = agents.find((r) => r.id === "cc-style");
+      assert.ok(a);
+      assert.deepEqual(a!.suggestedTools, ["Read", "Glob", "Grep"]);
+    });
+  });
+
+  it("parses tools as comma-separated string", () => {
+    withTmpCwd((dir) => {
+      writeFile(dir, ".oh/agents/comma.md", `---\nname: Comma\ndescription: x\ntools: Read, Edit, Bash\n---\nbody\n`);
+      const a = discoverMarkdownAgents().find((r) => r.id === "comma");
+      assert.ok(a);
+      assert.deepEqual(a!.suggestedTools, ["Read", "Edit", "Bash"]);
+    });
+  });
+
+  it("parses model + isolation + disallowedTools fields", () => {
+    withTmpCwd((dir) => {
+      writeFile(
+        dir,
+        ".oh/agents/full.md",
+        `---\nname: Full\ndescription: x\ntools: Read Edit Bash\ndisallowedTools: Write\nmodel: sonnet\nisolation: worktree\n---\nbody\n`,
+      );
+      const a = discoverMarkdownAgents().find((r) => r.id === "full");
+      assert.ok(a);
+      assert.equal(a!.model, "sonnet");
+      assert.equal(a!.isolation, "worktree");
+      assert.deepEqual(a!.disallowedTools, ["Write"]);
+    });
+  });
+
+  it("rejects invalid isolation value (silently ignored)", () => {
+    withTmpCwd((dir) => {
+      writeFile(dir, ".oh/agents/badiso.md", `---\nname: Bad\ndescription: x\nisolation: bogus\n---\n`);
+      const a = discoverMarkdownAgents().find((r) => r.id === "badiso");
+      assert.ok(a);
+      assert.equal(a!.isolation, undefined);
+    });
+  });
+
+  it("discovers agents from .claude/agents/ in addition to .oh/agents/", () => {
+    withTmpCwd((dir) => {
+      writeFile(dir, ".oh/agents/oh-one.md", `---\nname: OH One\ndescription: x\n---\n`);
+      writeFile(dir, ".claude/agents/cc-one.md", `---\nname: CC One\ndescription: y\n---\n`);
+      const agents = discoverMarkdownAgents();
+      assert.ok(agents.find((r) => r.id === "oh-one"));
+      assert.ok(agents.find((r) => r.id === "cc-one"));
+    });
+  });
+
+  it("OH paths take precedence over .claude paths on id collision", () => {
+    withTmpCwd((dir) => {
+      writeFile(dir, ".oh/agents/dup.md", `---\nname: From OH\ndescription: oh\n---\n`);
+      writeFile(dir, ".claude/agents/dup.md", `---\nname: From CC\ndescription: cc\n---\n`);
+      const agents = discoverMarkdownAgents().filter((r) => r.id === "dup");
+      assert.equal(agents.length, 1);
+      assert.equal(agents[0]!.name, "From OH");
+    });
   });
 });

--- a/src/agents/roles.ts
+++ b/src/agents/roles.ts
@@ -14,8 +14,14 @@ export type AgentRole = {
   name: string;
   description: string;
   systemPromptSupplement: string;
-  /** Suggested tools to include (empty = all tools) */
+  /** Suggested tools to include (empty = all tools) — Anthropic alias: `tools` */
   suggestedTools?: string[];
+  /** Tool denylist applied after suggestedTools — Anthropic standard: `disallowedTools` */
+  disallowedTools?: string[];
+  /** Per-agent model override (e.g. "sonnet", "opus", "haiku", or a full model ID) */
+  model?: string;
+  /** Isolation mode for sub-agent execution. Default: inherits parent. */
+  isolation?: "none" | "worktree";
 };
 
 const roles: AgentRole[] = [
@@ -176,15 +182,39 @@ import { basename, join } from "node:path";
 
 const PROJECT_AGENTS_DIR = join(".oh", "agents");
 const GLOBAL_AGENTS_DIR = join(homedir(), ".oh", "agents");
+// Claude Code ecosystem mirror paths
+const CC_PROJECT_AGENTS_DIR = join(".claude", "agents");
+const CC_GLOBAL_AGENTS_DIR = join(homedir(), ".claude", "agents");
+
+/** Parse a frontmatter list value. Accepts `[a, b]` (YAML inline) OR `a b c` (Claude Code style). */
+function parseAgentList(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+  // Claude Code spec: comma-separated OR space-separated bare tokens. Handle both.
+  return trimmed
+    .replace(/^["']|["']$/g, "")
+    .split(/[,\s]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
 
 /**
  * Parse a markdown agent file into an AgentRole.
  *
- * Format:
+ * Format (OH-native + Claude Code interoperable):
  * ---
  * name: My Agent
  * description: What it does
- * tools: [Read, Grep, Bash]
+ * tools: Read, Grep, Bash         # space- or comma-separated, OR YAML array
+ * disallowedTools: Write, Edit    # tool denylist
+ * model: sonnet                   # model override
+ * isolation: worktree             # explicit isolation mode
  * ---
  *
  * System prompt content...
@@ -196,7 +226,10 @@ function parseAgentMarkdown(raw: string, filePath: string): AgentRole | null {
   const fm = fmMatch[1]!;
   const nameMatch = fm.match(/^name:\s*(.+)$/m);
   const descMatch = fm.match(/^description:\s*(.+)$/m);
-  const toolsMatch = fm.match(/^tools:\s*\[(.+)\]$/m);
+  const toolsMatch = fm.match(/^tools:\s*(.+)$/m);
+  const disallowedMatch = fm.match(/^disallowedTools:\s*(.+)$/m) ?? fm.match(/^disallowed-tools:\s*(.+)$/m);
+  const modelMatch = fm.match(/^model:\s*(.+)$/m);
+  const isolationMatch = fm.match(/^isolation:\s*(.+)$/m);
 
   const fmEnd = raw.indexOf("---", raw.indexOf("---") + 3);
   const content = fmEnd > 0 ? raw.slice(fmEnd + 3).trim() : "";
@@ -205,12 +238,18 @@ function parseAgentMarkdown(raw: string, filePath: string): AgentRole | null {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-");
 
+  const isolation = isolationMatch?.[1]?.trim().replace(/^["']|["']$/g, "");
+  const validIsolation = isolation === "worktree" || isolation === "none" ? isolation : undefined;
+
   return {
     id,
     name: nameMatch?.[1]?.trim() ?? id,
     description: descMatch?.[1]?.trim() ?? "",
     systemPromptSupplement: content,
-    suggestedTools: toolsMatch ? toolsMatch[1]!.split(",").map((t) => t.trim()) : undefined,
+    suggestedTools: toolsMatch ? parseAgentList(toolsMatch[1]!) : undefined,
+    disallowedTools: disallowedMatch ? parseAgentList(disallowedMatch[1]!) : undefined,
+    model: modelMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
+    isolation: validIsolation,
   };
 }
 
@@ -230,9 +269,21 @@ function loadAgentsFromDir(dir: string): AgentRole[] {
     .filter((r): r is AgentRole => r !== null);
 }
 
-/** Discover markdown agent roles from .oh/agents/ and ~/.oh/agents/ */
+/** Discover markdown agent roles from .oh/agents/ + ~/.oh/agents/ + .claude/agents/ + ~/.claude/agents/ */
 export function discoverMarkdownAgents(): AgentRole[] {
-  return [...loadAgentsFromDir(PROJECT_AGENTS_DIR), ...loadAgentsFromDir(GLOBAL_AGENTS_DIR)];
+  const all = [
+    ...loadAgentsFromDir(PROJECT_AGENTS_DIR),
+    ...loadAgentsFromDir(GLOBAL_AGENTS_DIR),
+    ...loadAgentsFromDir(CC_PROJECT_AGENTS_DIR),
+    ...loadAgentsFromDir(CC_GLOBAL_AGENTS_DIR),
+  ];
+  // De-duplicate by id (first wins — OH paths take precedence over .claude paths)
+  const seen = new Set<string>();
+  return all.filter((r) => {
+    if (seen.has(r.id)) return false;
+    seen.add(r.id);
+    return true;
+  });
 }
 
 /** Get a role by ID (checks built-in first, then markdown agents) */

--- a/src/agents/roles.ts
+++ b/src/agents/roles.ts
@@ -22,6 +22,10 @@ export type AgentRole = {
   model?: string;
   /** Isolation mode for sub-agent execution. Default: inherits parent. */
   isolation?: "none" | "worktree";
+  /** Per-agent MCP servers injected only when this agent runs (parsed via raw passthrough; dispatcher wiring is a future task). */
+  mcpServers?: Record<string, unknown>;
+  /** Per-agent hooks (parsed via raw passthrough; dispatcher wiring is a future task). */
+  hooks?: Record<string, unknown>;
 };
 
 const roles: AgentRole[] = [
@@ -241,6 +245,11 @@ function parseAgentMarkdown(raw: string, filePath: string): AgentRole | null {
   const isolation = isolationMatch?.[1]?.trim().replace(/^["']|["']$/g, "");
   const validIsolation = isolation === "worktree" || isolation === "none" ? isolation : undefined;
 
+  // Parse optional inline-JSON fields (mcpServers, hooks). These are block fields in
+  // Anthropic's YAML but we support single-line JSON for lightweight frontmatter use.
+  const mcpServersMatch = fm.match(/^mcpServers:\s*(\{[\s\S]*?\})\s*$/m);
+  const hooksMatch = fm.match(/^hooks:\s*(\{[\s\S]*?\})\s*$/m);
+
   return {
     id,
     name: nameMatch?.[1]?.trim() ?? id,
@@ -250,7 +259,18 @@ function parseAgentMarkdown(raw: string, filePath: string): AgentRole | null {
     disallowedTools: disallowedMatch ? parseAgentList(disallowedMatch[1]!) : undefined,
     model: modelMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
     isolation: validIsolation,
+    mcpServers: mcpServersMatch ? tryParseJson(mcpServersMatch[1]!) : undefined,
+    hooks: hooksMatch ? tryParseJson(hooksMatch[1]!) : undefined,
   };
+}
+
+function tryParseJson(raw: string): Record<string, unknown> | undefined {
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Load agent roles from a directory of .md files */

--- a/src/commands/ai.ts
+++ b/src/commands/ai.ts
@@ -125,7 +125,7 @@ export function registerAICommands(register: (name: string, description: string,
     return { output: lines.join("\n"), handled: true };
   });
 
-  register("plugins", "Manage plugins: list, search, install, uninstall, marketplace", (args) => {
+  const pluginsHandler = (args: string) => {
     const { discoverPlugins, discoverSkills } = require("../harness/plugins.js");
     const {
       searchMarketplace,
@@ -142,6 +142,23 @@ export function registerAICommands(register: (name: string, description: string,
     const parts = args.trim().split(/\s+/);
     const subcommand = parts[0] ?? "";
     const rest = parts.slice(1).join(" ");
+
+    if (subcommand === "info" && rest) {
+      const installed = getInstalledPlugins();
+      const p = installed.find((x: { name: string }) => x.name === rest);
+      if (!p) return { output: `Plugin "${rest}" not found among installed plugins.`, handled: true };
+      const lines = [
+        `${p.name}@${p.version}`,
+        p.description ? `  ${p.description}` : "",
+        p.author ? `  by ${p.author}` : "",
+        p.license ? `  license: ${p.license}` : "",
+        p.homepage ? `  homepage: ${p.homepage}` : "",
+        p.keywords?.length ? `  keywords: ${p.keywords.join(", ")}` : "",
+        `  marketplace: ${p.marketplace}`,
+        `  cachePath: ${p.cachePath}`,
+      ].filter(Boolean);
+      return { output: lines.join("\n"), handled: true };
+    }
 
     if (subcommand === "marketplace") {
       const action = parts[1];
@@ -229,14 +246,18 @@ export function registerAICommands(register: (name: string, description: string,
 
     lines.push("");
     lines.push("Commands:");
-    lines.push("  /plugins search <query>          Search marketplaces");
-    lines.push("  /plugins install <name>          Install from marketplace");
-    lines.push("  /plugins uninstall <name>        Remove a plugin");
-    lines.push("  /plugins marketplace add <src>   Add a marketplace");
-    lines.push("  /plugins marketplace             List marketplaces");
+    lines.push("  /plugin info <name>              Show full manifest for a plugin");
+    lines.push("  /plugin search <query>           Search marketplaces");
+    lines.push("  /plugin install <name>           Install from marketplace");
+    lines.push("  /plugin uninstall <name>         Remove a plugin");
+    lines.push("  /plugin marketplace add <src>    Add a marketplace");
+    lines.push("  /plugin marketplace              List marketplaces");
 
     return { output: lines.join("\n"), handled: true };
-  });
+  };
+
+  register("plugins", "Manage plugins: list, search, install, uninstall, marketplace, info", pluginsHandler);
+  register("plugin", "Alias of /plugins (Claude Code-style singular)", pluginsHandler);
 
   register("cybergotchi", "Manage your cybergotchi — feed · pet · rest · status · rename · reset", (args) => {
     return handleCybergotchiCommand(args);

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -1,12 +1,41 @@
 /**
- * Skill management commands — /skill-create, /skill-delete, /skill-edit, /skill-search, /skill-install
+ * Skill management commands — /skills, /skill-create, /skill-delete, /skill-edit, /skill-search, /skill-install
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { discoverSkills } from "../harness/plugins.js";
 import type { CommandHandler } from "./types.js";
 
 export function registerSkillCommands(register: (name: string, description: string, handler: CommandHandler) => void) {
+  register("skills", "List all available skills", () => {
+    const skills = discoverSkills();
+    if (skills.length === 0) {
+      return {
+        output: "No skills found. Create .oh/skills/*.md to add one, or run /skill-search to browse the registry.",
+        handled: true,
+      };
+    }
+    // Group by source for readability
+    const lines: string[] = ["Available skills:"];
+    const sourceLabel: Record<string, string> = {
+      project: "[project]",
+      global: "[global]",
+      plugin: "[plugin]",
+    };
+    // Sort: bundled-style (project, no path under .oh) first, then by source then name
+    const sorted = [...skills].sort((a, b) => {
+      if (a.source !== b.source) return a.source.localeCompare(b.source);
+      return a.name.localeCompare(b.name);
+    });
+    for (const s of sorted) {
+      const tag = sourceLabel[s.source] ?? `[${s.source}]`;
+      const desc = s.description ? `: ${s.description}` : "";
+      lines.push(`  - ${s.name} ${tag}${desc}`);
+    }
+    return { output: lines.join("\n"), handled: true };
+  });
+
   register("skill-create", "Create a new skill file", (args) => {
     const name = args.trim();
     if (!name) return { output: "Usage: /skill-create <name>", handled: true };
@@ -99,24 +128,41 @@ How to confirm the skill worked correctly.
     return { output: "Searching skills registry...", handled: true };
   });
 
-  register("skill-install", "Install a skill from the registry", (args) => {
-    const name = args.trim();
-    if (!name) return { output: "Usage: /skill-install <name>", handled: true };
-
-    import("../harness/skill-registry.js").then(async ({ fetchRegistry, installSkill }) => {
-      try {
-        const registry = await fetchRegistry();
-        const skill = registry.skills.find((s) => s.name.toLowerCase() === name.toLowerCase());
-        if (!skill) {
-          console.log(`Skill "${name}" not found in registry. Try /skill-search first.`);
-          return;
-        }
-        const path = await installSkill(skill);
-        console.log(`Installed skill "${skill.name}" to ${path}`);
-      } catch (err: any) {
-        console.log(`Installation failed: ${err.message}`);
+  register(
+    "skill-install",
+    "Install a skill from the registry. Use --accept-license=<SPDX> for non-permissive licenses.",
+    (args) => {
+      // Parse: <name> [--accept-license=<SPDX>]
+      const tokens = args.trim().split(/\s+/).filter(Boolean);
+      if (tokens.length === 0)
+        return { output: "Usage: /skill-install <name> [--accept-license=<SPDX>]", handled: true };
+      let name = "";
+      let acceptLicense: string | undefined;
+      for (const tok of tokens) {
+        if (tok.startsWith("--accept-license=")) acceptLicense = tok.slice("--accept-license=".length);
+        else if (!name) name = tok;
       }
-    });
-    return { output: `Installing skill "${name}"...`, handled: true };
-  });
+      if (!name) return { output: "Usage: /skill-install <name> [--accept-license=<SPDX>]", handled: true };
+
+      import("../harness/skill-registry.js").then(async ({ fetchRegistry, installSkill }) => {
+        try {
+          const registry = await fetchRegistry();
+          const skill = registry.skills.find((s) => s.name.toLowerCase() === name.toLowerCase());
+          if (!skill) {
+            console.log(`Skill "${name}" not found in registry. Try /skill-search first.`);
+            return;
+          }
+          const result = await installSkill(skill, { acceptLicense });
+          if (result.ok) {
+            console.log(`Installed skill "${skill.name}" to ${result.filePath}`);
+          } else {
+            console.log(result.message);
+          }
+        } catch (err: any) {
+          console.log(`Installation failed: ${err.message}`);
+        }
+      });
+      return { output: `Installing skill "${name}"...`, handled: true };
+    },
+  );
 }

--- a/src/harness/cc-plugin-integration.test.ts
+++ b/src/harness/cc-plugin-integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test: real Claude Code plugin layout.
+ *
+ * Simulates the `obra/superpowers` layout in a tmp dir and verifies that OH's
+ * discovery helpers surface the plugin manifest, directory-packaged skills,
+ * MCP servers, hooks, and LSP servers end-to-end — without actually running
+ * the marketplace install path (which requires the network).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeTmpDir, writeFile } from "../test-helpers.js";
+import { getPluginHooks, getPluginLspServers, getPluginMcpServers, parseCcPluginManifest } from "./marketplace.js";
+
+test("end-to-end: simulated obra/superpowers plugin surfaces everything", () => {
+  const root = makeTmpDir();
+
+  // 1) Plugin manifest
+  writeFile(
+    root,
+    ".claude-plugin/plugin.json",
+    JSON.stringify({
+      name: "superpowers",
+      description: "Core skills library for Claude Code: TDD, debugging, collaboration patterns",
+      version: "5.0.7",
+      author: { name: "Jesse Vincent", email: "jesse@fsck.com" },
+      license: "MIT",
+      homepage: "https://github.com/obra/superpowers",
+      keywords: ["skills", "tdd", "debugging"],
+    }),
+  );
+
+  // 2) Directory-packaged skills (two skills, each with companion files)
+  writeFile(
+    root,
+    "skills/brainstorming/SKILL.md",
+    `---\nname: brainstorming\ndescription: Explore user intent before implementation\nallowed-tools: Read Glob Grep\n---\nBody of brainstorming skill.\n`,
+  );
+  writeFile(root, "skills/brainstorming/reference.md", "# Reference companion\n");
+  writeFile(
+    root,
+    "skills/systematic-debugging/SKILL.md",
+    `---\nname: systematic-debugging\ndescription: Structured debugging approach\nallowed-tools: Read Bash Grep\n---\nBody of debugging skill.\n`,
+  );
+
+  // 3) MCP server config
+  writeFile(
+    root,
+    ".mcp.json",
+    JSON.stringify({
+      mcpServers: {
+        github: { command: "npx", args: ["-y", "@modelcontextprotocol/server-github"] },
+      },
+    }),
+  );
+
+  // 4) Hooks
+  writeFile(
+    root,
+    "hooks/hooks.json",
+    JSON.stringify({
+      PreToolUse: [{ matcher: "Bash", command: "echo pre-bash" }],
+    }),
+  );
+
+  // 5) LSP server config
+  writeFile(
+    root,
+    ".lsp.json",
+    JSON.stringify({
+      lspServers: { typescript: { command: "typescript-language-server", args: ["--stdio"] } },
+    }),
+  );
+
+  // Verify every piece is discovered via the public helpers
+
+  const manifest = parseCcPluginManifest(root);
+  assert.ok(manifest, "manifest should parse");
+  assert.equal(manifest!.name, "superpowers");
+  assert.equal(manifest!.version, "5.0.7");
+  assert.equal(manifest!.license, "MIT");
+  assert.deepEqual(manifest!.keywords, ["skills", "tdd", "debugging"]);
+
+  const mcp = getPluginMcpServers(root);
+  assert.ok(mcp, "mcp servers should be discovered");
+  assert.ok("github" in mcp!);
+
+  const hooks = getPluginHooks(root);
+  assert.ok(hooks, "hooks should be discovered");
+  assert.ok("PreToolUse" in hooks!);
+
+  const lsp = getPluginLspServers(root);
+  assert.ok(lsp, "lsp servers should be discovered");
+  assert.ok("typescript" in lsp!);
+});
+
+test("end-to-end: minimal plugin (manifest only, no extras)", () => {
+  const root = makeTmpDir();
+  writeFile(root, ".claude-plugin/plugin.json", JSON.stringify({ name: "minimal", description: "bare" }));
+  assert.ok(parseCcPluginManifest(root));
+  assert.equal(getPluginMcpServers(root), null);
+  assert.equal(getPluginHooks(root), null);
+  assert.equal(getPluginLspServers(root), null);
+});
+
+test("end-to-end: malformed plugin files are safely skipped", () => {
+  const root = makeTmpDir();
+  writeFile(root, ".claude-plugin/plugin.json", JSON.stringify({ name: "ok", description: "ok" }));
+  writeFile(root, ".mcp.json", "{ this is not json");
+  writeFile(root, "hooks/hooks.json", "also not json");
+  writeFile(root, ".lsp.json", "nope");
+  assert.ok(parseCcPluginManifest(root));
+  assert.equal(getPluginMcpServers(root), null);
+  assert.equal(getPluginHooks(root), null);
+  assert.equal(getPluginLspServers(root), null);
+});

--- a/src/harness/marketplace.test.ts
+++ b/src/harness/marketplace.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { makeTmpDir, writeFile } from "../test-helpers.js";
-import { parseCcPluginManifest } from "./marketplace.js";
+import {
+  ccMarketplaceToOh,
+  getPluginHooks,
+  getPluginMcpServers,
+  parseCcPluginManifest,
+  parseMarketplaceJson,
+} from "./marketplace.js";
 
 test("parseCcPluginManifest returns null when manifest absent", () => {
   const dir = makeTmpDir();
@@ -53,4 +59,122 @@ test("parseCcPluginManifest rejects manifest with non-string name/description", 
   const dir = makeTmpDir();
   writeFile(dir, ".claude-plugin/plugin.json", JSON.stringify({ name: 42, description: "y" }));
   assert.equal(parseCcPluginManifest(dir), null);
+});
+
+// ── CC marketplace.json parsing ──
+
+test("parseMarketplaceJson accepts CC source-typed entries", () => {
+  const cc = {
+    name: "superpowers-dev",
+    plugins: [
+      {
+        name: "superpowers",
+        description: "Core skills",
+        version: "5.0.7",
+        source: { source: "github", repo: "obra/superpowers", ref: "v5.0.7" },
+      },
+      {
+        name: "tools",
+        description: "Tools collection",
+        version: "1.0.0",
+        source: { source: "npm", package: "@scope/tools", version: "^1.0.0" },
+      },
+    ],
+  };
+  const m = parseMarketplaceJson(JSON.stringify(cc));
+  assert.ok(m);
+  assert.equal(m!.plugins.length, 2);
+  assert.deepEqual(m!.plugins[0]!.source, { type: "github", repo: "obra/superpowers" });
+  assert.deepEqual(m!.plugins[1]!.source, { type: "npm", package: "@scope/tools" });
+});
+
+test("parseMarketplaceJson skips relative-path sources (only resolvable inside marketplace repo)", () => {
+  const cc = {
+    name: "local-dev",
+    plugins: [
+      { name: "local", description: "x", source: "./plugins/local" },
+      { name: "remote", description: "y", source: { source: "github", repo: "a/b" } },
+    ],
+  };
+  const m = parseMarketplaceJson(JSON.stringify(cc));
+  assert.ok(m);
+  assert.equal(m!.plugins.length, 1);
+  assert.equal(m!.plugins[0]!.name, "remote");
+});
+
+test("parseMarketplaceJson accepts OH-native marketplace format", () => {
+  const oh = {
+    name: "oh-marketplace",
+    version: 1,
+    plugins: [{ name: "p1", description: "x", version: "1.0.0", source: { type: "github", repo: "a/b" } }],
+  };
+  const m = parseMarketplaceJson(JSON.stringify(oh));
+  assert.ok(m);
+  assert.equal(m!.plugins.length, 1);
+  assert.deepEqual(m!.plugins[0]!.source, { type: "github", repo: "a/b" });
+});
+
+test("parseMarketplaceJson returns null for invalid JSON", () => {
+  assert.equal(parseMarketplaceJson("not json"), null);
+});
+
+test("parseMarketplaceJson returns null for missing plugins array", () => {
+  assert.equal(parseMarketplaceJson(JSON.stringify({ name: "x" })), null);
+});
+
+test("ccMarketplaceToOh preserves description + version + author", () => {
+  const cc = {
+    name: "x",
+    description: "Test marketplace",
+    plugins: [
+      {
+        name: "p1",
+        description: "desc",
+        version: "2.0.0",
+        author: { name: "Alice", email: "a@b.com" },
+        source: { source: "url" as const, url: "https://example.com/p.tgz" },
+      },
+    ],
+  };
+  const oh = ccMarketplaceToOh(cc);
+  assert.equal(oh.description, "Test marketplace");
+  assert.equal(oh.plugins[0]!.version, "2.0.0");
+  assert.equal(oh.plugins[0]!.author, "Alice");
+});
+
+// ── Plugin-shipped extras ──
+
+test("getPluginMcpServers returns null when .mcp.json absent", () => {
+  const dir = makeTmpDir();
+  assert.equal(getPluginMcpServers(dir), null);
+});
+
+test("getPluginMcpServers reads { mcpServers: {...} } shape", () => {
+  const dir = makeTmpDir();
+  const cfg = { mcpServers: { excel: { command: "npx", args: ["excel-mcp"] } } };
+  writeFile(dir, ".mcp.json", JSON.stringify(cfg));
+  const servers = getPluginMcpServers(dir);
+  assert.ok(servers);
+  assert.ok("excel" in servers!);
+});
+
+test("getPluginMcpServers also accepts bare server map", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".mcp.json", JSON.stringify({ excel: { command: "npx" } }));
+  const servers = getPluginMcpServers(dir);
+  assert.ok(servers);
+  assert.ok("excel" in servers!);
+});
+
+test("getPluginHooks reads hooks/hooks.json", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, "hooks/hooks.json", JSON.stringify({ PreToolUse: [{ command: "echo pre" }] }));
+  const hooks = getPluginHooks(dir);
+  assert.ok(hooks);
+  assert.ok("PreToolUse" in hooks!);
+});
+
+test("getPluginHooks returns null when absent", () => {
+  const dir = makeTmpDir();
+  assert.equal(getPluginHooks(dir), null);
 });

--- a/src/harness/marketplace.test.ts
+++ b/src/harness/marketplace.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeTmpDir, writeFile } from "../test-helpers.js";
+import { parseCcPluginManifest } from "./marketplace.js";
+
+test("parseCcPluginManifest returns null when manifest absent", () => {
+  const dir = makeTmpDir();
+  assert.equal(parseCcPluginManifest(dir), null);
+});
+
+test("parseCcPluginManifest reads minimal valid manifest", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".claude-plugin/plugin.json", JSON.stringify({ name: "x", description: "y" }));
+  const m = parseCcPluginManifest(dir);
+  assert.ok(m);
+  assert.equal(m!.name, "x");
+  assert.equal(m!.description, "y");
+});
+
+test("parseCcPluginManifest reads full manifest with author/license/keywords", () => {
+  const dir = makeTmpDir();
+  const manifest = {
+    name: "superpowers",
+    description: "Core skills library",
+    version: "5.0.7",
+    author: { name: "Jesse Vincent", email: "jesse@fsck.com" },
+    license: "MIT",
+    homepage: "https://github.com/obra/superpowers",
+    keywords: ["skills", "tdd"],
+  };
+  writeFile(dir, ".claude-plugin/plugin.json", JSON.stringify(manifest));
+  const m = parseCcPluginManifest(dir);
+  assert.ok(m);
+  assert.equal(m!.version, "5.0.7");
+  assert.equal(m!.license, "MIT");
+  assert.deepEqual(m!.keywords, ["skills", "tdd"]);
+});
+
+test("parseCcPluginManifest rejects invalid JSON", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".claude-plugin/plugin.json", "{ this is not valid json");
+  assert.equal(parseCcPluginManifest(dir), null);
+});
+
+test("parseCcPluginManifest rejects manifest missing required fields", () => {
+  const dir = makeTmpDir();
+  // Missing description
+  writeFile(dir, ".claude-plugin/plugin.json", JSON.stringify({ name: "incomplete" }));
+  assert.equal(parseCcPluginManifest(dir), null);
+});
+
+test("parseCcPluginManifest rejects manifest with non-string name/description", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".claude-plugin/plugin.json", JSON.stringify({ name: 42, description: "y" }));
+  assert.equal(parseCcPluginManifest(dir), null);
+});

--- a/src/harness/marketplace.test.ts
+++ b/src/harness/marketplace.test.ts
@@ -4,6 +4,7 @@ import { makeTmpDir, writeFile } from "../test-helpers.js";
 import {
   ccMarketplaceToOh,
   getPluginHooks,
+  getPluginLspServers,
   getPluginMcpServers,
   parseCcPluginManifest,
   parseMarketplaceJson,
@@ -177,4 +178,24 @@ test("getPluginHooks reads hooks/hooks.json", () => {
 test("getPluginHooks returns null when absent", () => {
   const dir = makeTmpDir();
   assert.equal(getPluginHooks(dir), null);
+});
+
+test("getPluginLspServers reads { lspServers: {...} } shape", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".lsp.json", JSON.stringify({ lspServers: { typescript: { command: "tsserver" } } }));
+  const lsp = getPluginLspServers(dir);
+  assert.ok(lsp);
+  assert.ok("typescript" in lsp!);
+});
+
+test("getPluginLspServers also accepts bare server map", () => {
+  const dir = makeTmpDir();
+  writeFile(dir, ".lsp.json", JSON.stringify({ typescript: { command: "tsserver" } }));
+  const lsp = getPluginLspServers(dir);
+  assert.ok(lsp);
+  assert.ok("typescript" in lsp!);
+});
+
+test("getPluginLspServers returns null when absent", () => {
+  assert.equal(getPluginLspServers(makeTmpDir()), null);
 });

--- a/src/harness/marketplace.ts
+++ b/src/harness/marketplace.ts
@@ -188,6 +188,23 @@ export function getPluginHooks(cachePath: string): Record<string, unknown> | nul
   }
 }
 
+/** Discover plugin-shipped LSP servers from `cachePath/.lsp.json`. Returns raw config for the runtime to register. */
+export function getPluginLspServers(cachePath: string): Record<string, unknown> | null {
+  const path = join(cachePath, ".lsp.json");
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (data && typeof data === "object") {
+      if ("lspServers" in data && typeof data.lspServers === "object")
+        return data.lspServers as Record<string, unknown>;
+      return data as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Marketplace Management ──
 
 /** Add a marketplace from a URL, GitHub repo, or local path.

--- a/src/harness/marketplace.ts
+++ b/src/harness/marketplace.ts
@@ -83,51 +83,170 @@ export function parseCcPluginManifest(pluginRoot: string): CcPluginManifest | nu
   }
 }
 
-// ── Marketplace Management ──
+/** Claude Code marketplace.json format — superset of OH's marketplace.json with source-typed entries. */
+export type CcMarketplacePluginSource =
+  | string // relative path "./plugins/foo"
+  | { source: "github"; repo: string; ref?: string }
+  | { source: "url"; url: string }
+  | { source: "npm"; package: string; version?: string };
 
-/** Add a marketplace from a URL, GitHub repo, or local path */
-export function addMarketplace(nameOrUrl: string): Marketplace | null {
-  mkdirSync(MARKETPLACE_DIR, { recursive: true });
+export type CcMarketplaceEntry = {
+  name: string;
+  description?: string;
+  version?: string;
+  author?: { name?: string; email?: string } | string;
+  source: CcMarketplacePluginSource;
+};
 
-  // Fetch marketplace.json
-  let data: string;
-  let marketplaceName: string;
+export type CcMarketplace = {
+  name: string;
+  description?: string;
+  owner?: { name?: string; email?: string };
+  plugins: CcMarketplaceEntry[];
+};
 
-  if (nameOrUrl.startsWith("http")) {
-    // URL
-    try {
-      data = execSync(`curl -sL "${nameOrUrl}/marketplace.json"`, { encoding: "utf-8", timeout: 10_000 });
-      marketplaceName = new URL(nameOrUrl).hostname;
-    } catch {
-      return null;
-    }
-  } else if (nameOrUrl.includes("/") && !nameOrUrl.startsWith(".")) {
-    // GitHub repo (owner/repo format)
-    try {
-      const url = `https://raw.githubusercontent.com/${nameOrUrl}/main/marketplace.json`;
-      data = execSync(`curl -sL "${url}"`, { encoding: "utf-8", timeout: 10_000 });
-      marketplaceName = nameOrUrl.replace("/", "-");
-    } catch {
-      return null;
-    }
-  } else if (existsSync(join(nameOrUrl, "marketplace.json"))) {
-    // Local path
-    data = readFileSync(join(nameOrUrl, "marketplace.json"), "utf-8");
-    marketplaceName = basename(nameOrUrl);
-  } else {
-    return null;
+/** Convert a CcMarketplace to OH's internal Marketplace type (lossy: dropped fields like `owner` are not stored). */
+export function ccMarketplaceToOh(cc: CcMarketplace): Marketplace {
+  const plugins: MarketplaceEntry[] = [];
+  for (const p of cc.plugins) {
+    const ohSource = ccSourceToOh(p.source);
+    if (!ohSource) continue; // Skip relative-path sources — only resolvable inside the marketplace repo
+    plugins.push({
+      name: p.name,
+      description: p.description ?? "",
+      version: p.version ?? "0.0.0",
+      author: typeof p.author === "string" ? p.author : p.author?.name,
+      source: ohSource,
+    });
   }
+  return { name: cc.name, version: 1, description: cc.description, plugins };
+}
 
+function ccSourceToOh(src: CcMarketplacePluginSource): MarketplaceSource | null {
+  if (typeof src === "string") return null; // relative paths require marketplace-repo context
+  if (src.source === "github") return { type: "github", repo: src.repo };
+  if (src.source === "url") return { type: "url", url: src.url };
+  if (src.source === "npm") return { type: "npm", package: src.package };
+  return null;
+}
+
+/** Parse marketplace JSON text. Tries CC format (.claude-plugin/marketplace.json shape) first, falls back to OH-native. */
+export function parseMarketplaceJson(text: string): Marketplace | null {
+  let raw: unknown;
   try {
-    const marketplace = JSON.parse(data) as Marketplace;
-    if (!marketplace.plugins || !Array.isArray(marketplace.plugins)) return null;
-
-    marketplace.name = marketplace.name ?? marketplaceName;
-    writeFileSync(join(MARKETPLACE_DIR, `${marketplace.name}.json`), JSON.stringify(marketplace, null, 2));
-    return marketplace;
+    raw = JSON.parse(text);
   } catch {
     return null;
   }
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (!Array.isArray(obj.plugins)) return null;
+
+  // Detect CC format: any plugin entry has either a string `source` or `source.source` (kind tag)
+  const looksCc = obj.plugins.some((p: unknown) => {
+    if (!p || typeof p !== "object") return false;
+    const s = (p as Record<string, unknown>).source;
+    return typeof s === "string" || (s !== null && typeof s === "object" && "source" in (s as Record<string, unknown>));
+  });
+
+  if (looksCc) {
+    return ccMarketplaceToOh(obj as unknown as CcMarketplace);
+  }
+  // OH-native format
+  return obj as unknown as Marketplace;
+}
+
+/** Discover plugin-shipped MCP servers from `cachePath/.mcp.json`. Returns raw object for the runtime to merge. */
+export function getPluginMcpServers(cachePath: string): Record<string, unknown> | null {
+  const path = join(cachePath, ".mcp.json");
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    // Claude Code shape: { "mcpServers": { name: { command, args, env, ... } } }
+    // Some plugins store the inner map directly. Accept both.
+    if (data && typeof data === "object") {
+      if ("mcpServers" in data && typeof data.mcpServers === "object")
+        return data.mcpServers as Record<string, unknown>;
+      return data as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Discover plugin-shipped hooks from `cachePath/hooks/hooks.json`. Returns raw config for the runtime to register. */
+export function getPluginHooks(cachePath: string): Record<string, unknown> | null {
+  const path = join(cachePath, "hooks", "hooks.json");
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (data && typeof data === "object") return data as Record<string, unknown>;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Marketplace Management ──
+
+/** Add a marketplace from a URL, GitHub repo, or local path.
+ * Probes for both OH-native `marketplace.json` and Claude Code `.claude-plugin/marketplace.json`.
+ */
+export function addMarketplace(nameOrUrl: string): Marketplace | null {
+  mkdirSync(MARKETPLACE_DIR, { recursive: true });
+
+  // Candidate filenames to try, in priority order
+  const candidatePaths = ["marketplace.json", ".claude-plugin/marketplace.json"];
+
+  let data: string | null = null;
+  let marketplaceName: string;
+
+  if (nameOrUrl.startsWith("http")) {
+    marketplaceName = new URL(nameOrUrl).hostname;
+    for (const fname of candidatePaths) {
+      try {
+        const text = execSync(`curl -sfL "${nameOrUrl}/${fname}"`, { encoding: "utf-8", timeout: 10_000 });
+        if (text.trim()) {
+          data = text;
+          break;
+        }
+      } catch {
+        /* try next */
+      }
+    }
+  } else if (nameOrUrl.includes("/") && !nameOrUrl.startsWith(".")) {
+    marketplaceName = nameOrUrl.replace("/", "-");
+    for (const fname of candidatePaths) {
+      try {
+        const url = `https://raw.githubusercontent.com/${nameOrUrl}/main/${fname}`;
+        const text = execSync(`curl -sfL "${url}"`, { encoding: "utf-8", timeout: 10_000 });
+        if (text.trim()) {
+          data = text;
+          break;
+        }
+      } catch {
+        /* try next */
+      }
+    }
+  } else {
+    marketplaceName = basename(nameOrUrl);
+    for (const fname of candidatePaths) {
+      const path = join(nameOrUrl, fname);
+      if (existsSync(path)) {
+        data = readFileSync(path, "utf-8");
+        break;
+      }
+    }
+  }
+
+  if (!data) return null;
+
+  const marketplace = parseMarketplaceJson(data);
+  if (!marketplace) return null;
+  marketplace.name = marketplace.name ?? marketplaceName;
+  writeFileSync(join(MARKETPLACE_DIR, `${marketplace.name}.json`), JSON.stringify(marketplace, null, 2));
+  return marketplace;
 }
 
 /** Remove a marketplace */

--- a/src/harness/marketplace.ts
+++ b/src/harness/marketplace.ts
@@ -8,13 +8,16 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
 const MARKETPLACE_DIR = join(homedir(), ".oh", "marketplaces");
 const PLUGIN_CACHE_DIR = join(homedir(), ".oh", "plugins", "cache");
 const INSTALLED_PLUGINS_FILE = join(homedir(), ".oh", "plugins", "installed.json");
+
+// Claude Code plugin manifest path relative to plugin root
+const CC_MANIFEST_PATH = join(".claude-plugin", "plugin.json");
 
 // ── Types ──
 
@@ -45,7 +48,40 @@ export type InstalledPlugin = {
   marketplace: string;
   installedAt: number;
   cachePath: string;
+  /** Optional fields populated from `.claude-plugin/plugin.json` if present */
+  description?: string;
+  author?: string;
+  license?: string;
+  homepage?: string;
+  keywords?: string[];
 };
+
+/** Claude Code plugin manifest (`.claude-plugin/plugin.json`).
+ * Required: name, description. All other fields optional.
+ */
+export type CcPluginManifest = {
+  name: string;
+  description: string;
+  version?: string;
+  author?: { name?: string; email?: string } | string;
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  keywords?: string[];
+};
+
+/** Parse a `.claude-plugin/plugin.json` file at the given plugin root, or null if missing/invalid. */
+export function parseCcPluginManifest(pluginRoot: string): CcPluginManifest | null {
+  const path = join(pluginRoot, CC_MANIFEST_PATH);
+  if (!existsSync(path)) return null;
+  try {
+    const m = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof m?.name !== "string" || typeof m?.description !== "string") return null;
+    return m as CcPluginManifest;
+  } catch {
+    return null;
+  }
+}
 
 // ── Marketplace Management ──
 
@@ -240,14 +276,101 @@ export function uninstallPlugin(name: string): boolean {
   return true;
 }
 
-/** Get all installed plugins */
+/** Get all installed plugins.
+ * Sources merged in priority order:
+ * 1. installed.json (plugins installed via /plugin install or addMarketplace flow)
+ * 2. CC-style plugins discovered in PLUGIN_CACHE_DIR via .claude-plugin/plugin.json
+ *    (covers plugins manually dropped in the cache, or installed by parallel tooling)
+ * Plugins from #1 are enriched with manifest data if their cachePath has one.
+ * De-duplication is by cachePath.
+ */
 export function getInstalledPlugins(): InstalledPlugin[] {
-  if (!existsSync(INSTALLED_PLUGINS_FILE)) return [];
+  const recorded: InstalledPlugin[] = (() => {
+    if (!existsSync(INSTALLED_PLUGINS_FILE)) return [];
+    try {
+      return JSON.parse(readFileSync(INSTALLED_PLUGINS_FILE, "utf-8")) as InstalledPlugin[];
+    } catch {
+      return [];
+    }
+  })();
+
+  // Enrich recorded plugins from their CC manifest if present
+  const enriched = recorded.map((p) => mergeManifest(p, parseCcPluginManifest(p.cachePath)));
+  const seenPaths = new Set(enriched.map((p) => p.cachePath));
+
+  // Discover CC-style plugins in PLUGIN_CACHE_DIR not already recorded
+  const discovered: InstalledPlugin[] = [];
+  if (existsSync(PLUGIN_CACHE_DIR)) {
+    try {
+      for (const nameEntry of readdirSync(PLUGIN_CACHE_DIR)) {
+        const nameDir = join(PLUGIN_CACHE_DIR, nameEntry);
+        if (!safeIsDirectory(nameDir)) continue;
+        // Plugin can sit either at <name>/ or <name>/<version>/
+        const candidates = [nameDir, ...listSubdirs(nameDir)];
+        for (const root of candidates) {
+          if (seenPaths.has(root)) continue;
+          const manifest = parseCcPluginManifest(root);
+          if (!manifest) continue;
+          discovered.push({
+            name: manifest.name,
+            version: manifest.version ?? "0.0.0",
+            marketplace: "discovered",
+            installedAt: tryStatTime(root),
+            cachePath: root,
+            ...projectManifestFields(manifest),
+          });
+          seenPaths.add(root);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return [...enriched, ...discovered];
+}
+
+function safeIsDirectory(path: string): boolean {
   try {
-    return JSON.parse(readFileSync(INSTALLED_PLUGINS_FILE, "utf-8"));
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function listSubdirs(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .map((entry) => join(dir, entry))
+      .filter((p) => safeIsDirectory(p));
   } catch {
     return [];
   }
+}
+
+function tryStatTime(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return Date.now();
+  }
+}
+
+function projectManifestFields(
+  m: CcPluginManifest,
+): Pick<InstalledPlugin, "description" | "author" | "license" | "homepage" | "keywords"> {
+  return {
+    description: m.description,
+    author: typeof m.author === "string" ? m.author : m.author?.name,
+    license: m.license,
+    homepage: m.homepage,
+    keywords: m.keywords,
+  };
+}
+
+function mergeManifest(plugin: InstalledPlugin, manifest: CcPluginManifest | null): InstalledPlugin {
+  if (!manifest) return plugin;
+  return { ...plugin, ...projectManifestFields(manifest) };
 }
 
 function saveInstalledPlugin(plugin: InstalledPlugin): void {

--- a/src/harness/plugins.test.ts
+++ b/src/harness/plugins.test.ts
@@ -89,6 +89,9 @@ test("skillsToPrompt formats as markdown list", () => {
       trigger: "deploy",
       tools: ["Bash"],
       args: undefined,
+      whenToUse: undefined,
+      license: undefined,
+      paths: undefined,
       content: "",
       filePath: "/tmp/deploy.md",
       source: "project",
@@ -109,6 +112,9 @@ test("skillsToPrompt hides skills with invokeModel: false", () => {
       trigger: undefined,
       tools: undefined,
       args: undefined,
+      whenToUse: undefined,
+      license: undefined,
+      paths: undefined,
       content: "",
       filePath: "/tmp/visible.md",
       source: "project",
@@ -120,6 +126,9 @@ test("skillsToPrompt hides skills with invokeModel: false", () => {
       trigger: undefined,
       tools: undefined,
       args: undefined,
+      whenToUse: undefined,
+      license: undefined,
+      paths: undefined,
       content: "",
       filePath: "/tmp/hidden.md",
       source: "project",
@@ -133,4 +142,117 @@ test("skillsToPrompt hides skills with invokeModel: false", () => {
 
 test("skillsToPrompt returns empty string for empty array", () => {
   assert.equal(skillsToPrompt([]), "");
+});
+
+// ── Anthropic-style frontmatter alias tests ──
+
+test("parses Anthropic kebab `allowed-tools` (space-separated)", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/cc-style.md",
+      `---
+name: cc-style
+description: Anthropic-style skill
+allowed-tools: Read Glob Grep
+---
+body
+`,
+    );
+    const skill = findSkill("cc-style");
+    assert.ok(skill);
+    assert.deepEqual(skill!.tools, ["Read", "Glob", "Grep"]);
+  });
+});
+
+test("parses `allowed-tools` array form alongside camelCase `allowedTools`", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/dual.md",
+      `---
+name: dual
+description: Mixed style
+allowed-tools: [Bash, Read]
+---
+`,
+    );
+    const skill = findSkill("dual");
+    assert.ok(skill);
+    assert.deepEqual(skill!.tools!.sort(), ["Bash", "Read"]);
+  });
+});
+
+test("`disable-model-invocation: true` sets invokeModel false", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/hidden.md",
+      `---
+name: hidden
+description: Hidden skill
+disable-model-invocation: true
+---
+`,
+    );
+    const skill = findSkill("hidden");
+    assert.ok(skill);
+    assert.equal(skill!.invokeModel, false);
+  });
+});
+
+test("`argument-hint` aliases to args", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/with-args.md",
+      `---
+name: with-args
+description: Has args
+argument-hint: [--prod, --force]
+---
+`,
+    );
+    const skill = findSkill("with-args");
+    assert.ok(skill);
+    assert.deepEqual(skill!.args, ["--prod", "--force"]);
+  });
+});
+
+test("parses `license` and `paths` fields", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/licensed.md",
+      `---
+name: licensed
+description: Has license + paths
+license: MIT
+paths: [src/**/*.ts, tests/**/*.ts]
+---
+`,
+    );
+    const skill = findSkill("licensed");
+    assert.ok(skill);
+    assert.equal(skill!.license, "MIT");
+    assert.deepEqual(skill!.paths, ["src/**/*.ts", "tests/**/*.ts"]);
+  });
+});
+
+test("`whenToUse` (Anthropic style) is parsed and stored", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/whentouse.md",
+      `---
+name: whentouse
+description: x
+when-to-use: When the user asks to refactor legacy code
+---
+`,
+    );
+    const skill = findSkill("whentouse");
+    assert.ok(skill);
+    assert.equal(skill!.whenToUse, "When the user asks to refactor legacy code");
+  });
 });

--- a/src/harness/plugins.test.ts
+++ b/src/harness/plugins.test.ts
@@ -92,6 +92,8 @@ test("skillsToPrompt formats as markdown list", () => {
       whenToUse: undefined,
       license: undefined,
       paths: undefined,
+      context: undefined,
+      agent: undefined,
       content: "",
       filePath: "/tmp/deploy.md",
       source: "project",
@@ -115,6 +117,8 @@ test("skillsToPrompt hides skills with invokeModel: false", () => {
       whenToUse: undefined,
       license: undefined,
       paths: undefined,
+      context: undefined,
+      agent: undefined,
       content: "",
       filePath: "/tmp/visible.md",
       source: "project",
@@ -129,6 +133,8 @@ test("skillsToPrompt hides skills with invokeModel: false", () => {
       whenToUse: undefined,
       license: undefined,
       paths: undefined,
+      context: undefined,
+      agent: undefined,
       content: "",
       filePath: "/tmp/hidden.md",
       source: "project",
@@ -275,6 +281,45 @@ test("flat layout still works alongside directory layout", () => {
     assert.equal(project.length, 2);
     const names = project.map((s) => s.name).sort();
     assert.deepEqual(names, ["dirsk", "flat"]);
+  });
+});
+
+test("parses `context: fork` + `agent: <type>` skill fields", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/fork-skill.md",
+      `---
+name: fork-skill
+description: Delegates to a sub-agent
+context: fork
+agent: code-reviewer
+---
+body
+`,
+    );
+    const s = findSkill("fork-skill");
+    assert.ok(s);
+    assert.equal(s!.context, "fork");
+    assert.equal(s!.agent, "code-reviewer");
+  });
+});
+
+test("invalid context value is silently ignored", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/bad-context.md",
+      `---
+name: bad-context
+description: x
+context: bogus
+---
+`,
+    );
+    const s = findSkill("bad-context");
+    assert.ok(s);
+    assert.equal(s!.context, undefined);
   });
 });
 

--- a/src/harness/plugins.test.ts
+++ b/src/harness/plugins.test.ts
@@ -239,6 +239,55 @@ paths: [src/**/*.ts, tests/**/*.ts]
   });
 });
 
+// ── Directory-packaged skill (skill-name/SKILL.md) tests ──
+
+test("directory-packaged skill: SKILL.md surfaces, sibling .md files are companions", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/skills/pdf-vision/SKILL.md",
+      `---
+name: pdf-vision
+description: Extract data from PDF drawings
+---
+Main skill content
+`,
+    );
+    writeFile(dir, ".oh/skills/pdf-vision/reference.md", "# Reference docs (companion, not a skill)\n");
+    writeFile(dir, ".oh/skills/pdf-vision/forms.md", "# Forms guide (companion, not a skill)\n");
+    const skills = discoverSkills();
+    const project = skills.filter((s) => s.source === "project");
+    // Only ONE skill registers, despite 3 .md files in the dir
+    assert.equal(project.length, 1);
+    assert.equal(project[0]!.name, "pdf-vision");
+  });
+});
+
+test("flat layout still works alongside directory layout", () => {
+  withTmpCwd((dir) => {
+    // Flat file
+    writeFile(dir, ".oh/skills/flat.md", `---\nname: flat\ndescription: Flat skill\n---\n`);
+    // Directory-packaged
+    writeFile(dir, ".oh/skills/dirsk/SKILL.md", `---\nname: dirsk\ndescription: Dir skill\n---\n`);
+    writeFile(dir, ".oh/skills/dirsk/notes.md", "# Companion\n");
+    const skills = discoverSkills();
+    const project = skills.filter((s) => s.source === "project");
+    assert.equal(project.length, 2);
+    const names = project.map((s) => s.name).sort();
+    assert.deepEqual(names, ["dirsk", "flat"]);
+  });
+});
+
+test("nested directory without SKILL.md still recurses (legacy behavior)", () => {
+  withTmpCwd((dir) => {
+    writeFile(dir, ".oh/skills/nested/a.md", `---\nname: a\ndescription: A\n---\n`);
+    writeFile(dir, ".oh/skills/nested/b.md", `---\nname: b\ndescription: B\n---\n`);
+    const skills = discoverSkills();
+    const project = skills.filter((s) => s.source === "project");
+    assert.equal(project.length, 2);
+  });
+});
+
 test("`whenToUse` (Anthropic style) is parsed and stored", () => {
   withTmpCwd((dir) => {
     writeFile(

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -13,7 +13,8 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export type SkillMetadata = {
   name: string;
@@ -21,9 +22,15 @@ export type SkillMetadata = {
   trigger: string | undefined;
   tools: string[] | undefined;
   args: string[] | undefined;
+  /** Optional natural-language hint for when this skill applies; concatenated to description for trigger matching */
+  whenToUse: string | undefined;
+  /** SPDX license identifier (e.g. "MIT", "Apache-2.0", "CC-BY-SA-4.0"). Used by install gate. */
+  license: string | undefined;
+  /** Glob patterns scoping skill auto-surfacing to specific file paths */
+  paths: string[] | undefined;
   content: string;
   filePath: string;
-  source: "project" | "global" | "plugin";
+  source: "bundled" | "project" | "global" | "plugin";
   /** When false, skill is hidden from system prompt until explicitly invoked */
   invokeModel: boolean;
 };
@@ -50,8 +57,29 @@ export type AgentTeamConfig = {
 
 const PROJECT_SKILLS_DIR = join(".oh", "skills");
 const GLOBAL_SKILLS_DIR = join(homedir(), ".oh", "skills");
+// Claude Code ecosystem mirror paths (Anthropic convention)
+const CC_PROJECT_SKILLS_DIR = join(".claude", "skills");
+const CC_GLOBAL_SKILLS_DIR = join(homedir(), ".claude", "skills");
+// Bundled skills shipped with the openharness package itself.
+// At runtime this resolves to <package-root>/data/skills/ both in dev (src/) and prod (dist/).
+const BUNDLED_SKILLS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "data", "skills");
 
-/** Parse YAML frontmatter from a skill markdown file */
+/** Parse a frontmatter list value. Accepts `[a, b]` (YAML inline) or `a b c` (space-separated, Anthropic spec). */
+function parseListValue(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+  // Strip surrounding quotes if present
+  const unquoted = trimmed.replace(/^["']|["']$/g, "");
+  return unquoted.split(/\s+/).filter(Boolean);
+}
+
+/** Parse YAML frontmatter from a skill markdown file. Accepts both OH camelCase and Anthropic kebab-case. */
 function parseSkillFrontmatter(content: string): Partial<SkillMetadata> {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return {};
@@ -65,26 +93,36 @@ function parseSkillFrontmatter(content: string): Partial<SkillMetadata> {
   const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
   if (descMatch) result.description = descMatch[1]!.trim();
 
+  // trigger: OH-native field; when-to-use / whenToUse: Anthropic-style hint (also used as trigger fallback)
   const triggerMatch = frontmatter.match(/^trigger:\s*(.+)$/m);
   if (triggerMatch) result.trigger = triggerMatch[1]!.trim();
+  const whenToUseMatch = frontmatter.match(/^(?:when-to-use|whenToUse):\s*(.+)$/m);
+  if (whenToUseMatch) result.whenToUse = whenToUseMatch[1]!.trim();
 
-  const toolsMatch = frontmatter.match(/^tools:\s*\[(.+)\]$/m);
-  if (toolsMatch) result.tools = toolsMatch[1]!.split(",").map((t) => t.trim());
-
-  // Also parse allowedTools (used by built-in skills) and merge with tools
-  const allowedToolsMatch = frontmatter.match(/^allowedTools:\s*\[(.+)\]$/m);
-  if (allowedToolsMatch) {
-    const allowed = allowedToolsMatch[1]!.split(",").map((t) => t.trim());
-    result.tools = result.tools ? [...new Set([...result.tools, ...allowed])] : allowed;
+  // tools / allowedTools / allowed-tools — array OR space-separated. Merge all forms found.
+  const toolsCollected = new Set<string>();
+  for (const re of [/^tools:\s*(.+)$/m, /^allowedTools:\s*(.+)$/m, /^allowed-tools:\s*(.+)$/m]) {
+    const m = frontmatter.match(re);
+    if (m) for (const t of parseListValue(m[1]!)) toolsCollected.add(t);
   }
+  if (toolsCollected.size > 0) result.tools = [...toolsCollected];
 
-  const argsMatch = frontmatter.match(/^args:\s*\[(.+)\]$/m);
-  if (argsMatch) result.args = argsMatch[1]!.split(",").map((a) => a.trim());
+  // args / argument-hint
+  const argsMatch = frontmatter.match(/^(?:args|argument-hint):\s*(.+)$/m);
+  if (argsMatch) result.args = parseListValue(argsMatch[1]!);
 
   // invokeModel: false OR disable-model-invocation: true → hidden from system prompt
   if (frontmatter.match(/^invokeModel:\s*false$/m) || frontmatter.match(/^disable-model-invocation:\s*true$/m)) {
     result.invokeModel = false;
   }
+
+  // license: SPDX identifier (e.g. MIT, Apache-2.0)
+  const licenseMatch = frontmatter.match(/^license:\s*(.+)$/m);
+  if (licenseMatch) result.license = licenseMatch[1]!.trim().replace(/^["']|["']$/g, "");
+
+  // paths: glob list — scopes auto-surfacing to matching files
+  const pathsMatch = frontmatter.match(/^paths:\s*(.+)$/m);
+  if (pathsMatch) result.paths = parseListValue(pathsMatch[1]!);
 
   return result;
 }
@@ -124,6 +162,9 @@ function loadSkillsFromDir(dir: string, source: SkillMetadata["source"]): SkillM
           trigger: meta.trigger,
           tools: meta.tools,
           args: meta.args,
+          whenToUse: meta.whenToUse,
+          license: meta.license,
+          paths: meta.paths,
           content,
           filePath,
           source,
@@ -136,11 +177,17 @@ function loadSkillsFromDir(dir: string, source: SkillMetadata["source"]): SkillM
     .filter((s): s is SkillMetadata => s !== null);
 }
 
-/** Discover all available skills from project + global dirs + installed plugins */
+/** Discover all available skills from bundled + project + global dirs + installed plugins */
 export function discoverSkills(): SkillMetadata[] {
   const skills: SkillMetadata[] = [];
+  // Bundled (shipped with the openharness package)
+  skills.push(...loadSkillsFromDir(BUNDLED_SKILLS_DIR, "bundled"));
+  // OH-native paths
   skills.push(...loadSkillsFromDir(PROJECT_SKILLS_DIR, "project"));
   skills.push(...loadSkillsFromDir(GLOBAL_SKILLS_DIR, "global"));
+  // Claude Code ecosystem mirror paths — same source labels (project/global)
+  skills.push(...loadSkillsFromDir(CC_PROJECT_SKILLS_DIR, "project"));
+  skills.push(...loadSkillsFromDir(CC_GLOBAL_SKILLS_DIR, "global"));
 
   // Load skills from installed marketplace plugins (namespaced as plugin-name:skill-name)
   try {
@@ -158,7 +205,14 @@ export function discoverSkills(): SkillMetadata[] {
     /* marketplace module may not be loaded yet */
   }
 
-  return skills;
+  // De-duplicate by name+filePath: if same skill appears in multiple paths (e.g. CC mirror), keep first.
+  const seen = new Set<string>();
+  return skills.filter((s) => {
+    const key = `${s.name}::${s.filePath}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /** Find a skill by name (case-insensitive) */
@@ -167,7 +221,7 @@ export function findSkill(name: string): SkillMetadata | null {
   return skills.find((s) => s.name.toLowerCase() === name.toLowerCase()) ?? null;
 }
 
-/** Find skills that match a trigger condition */
+/** Find skills that match a trigger condition (substring match against `trigger` field). */
 export function findTriggeredSkills(userMessage: string): SkillMetadata[] {
   const skills = discoverSkills();
   return skills.filter((s) => {

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -28,6 +28,10 @@ export type SkillMetadata = {
   license: string | undefined;
   /** Glob patterns scoping skill auto-surfacing to specific file paths */
   paths: string[] | undefined;
+  /** Execution context: "default" runs in the current agent, "fork" spawns a sub-agent (Anthropic extension) */
+  context: "default" | "fork" | undefined;
+  /** When `context: fork`, the sub-agent type to spawn (must match an AgentRole id) */
+  agent: string | undefined;
   content: string;
   filePath: string;
   source: "bundled" | "project" | "global" | "plugin";
@@ -124,6 +128,17 @@ function parseSkillFrontmatter(content: string): Partial<SkillMetadata> {
   const pathsMatch = frontmatter.match(/^paths:\s*(.+)$/m);
   if (pathsMatch) result.paths = parseListValue(pathsMatch[1]!);
 
+  // context: "default" | "fork" — when "fork", skill runs in a new sub-agent context
+  const contextMatch = frontmatter.match(/^context:\s*(.+)$/m);
+  if (contextMatch) {
+    const v = contextMatch[1]!.trim().replace(/^["']|["']$/g, "");
+    if (v === "fork" || v === "default") result.context = v;
+  }
+
+  // agent: sub-agent type name (only meaningful when context: fork)
+  const agentMatch = frontmatter.match(/^agent:\s*(.+)$/m);
+  if (agentMatch) result.agent = agentMatch[1]!.trim().replace(/^["']|["']$/g, "");
+
   return result;
 }
 
@@ -182,6 +197,8 @@ function loadSkillsFromDir(dir: string, source: SkillMetadata["source"]): SkillM
           whenToUse: meta.whenToUse,
           license: meta.license,
           paths: meta.paths,
+          context: meta.context,
+          agent: meta.agent,
           content,
           filePath,
           source,

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -127,11 +127,28 @@ function parseSkillFrontmatter(content: string): Partial<SkillMetadata> {
   return result;
 }
 
-/** Recursively collect all .md files from a directory tree */
+/** Recursively collect skill .md files from a directory tree.
+ * Anthropic / Claude Code convention: a directory containing `SKILL.md` is a single
+ * directory-packaged skill — only the SKILL.md surfaces; sibling .md files are
+ * companion documentation (referenced via Read at runtime). Directories without
+ * SKILL.md fall through to the legacy flat-file behavior (every .md is a skill).
+ */
 function walkMdFiles(dir: string): string[] {
   if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  // Directory-packaged skill: only SKILL.md counts; siblings are companions.
+  if (entries.includes("SKILL.md")) {
+    return [join(dir, "SKILL.md")];
+  }
+
   const results: string[] = [];
-  for (const entry of readdirSync(dir)) {
+  for (const entry of entries) {
     const full = join(dir, entry);
     try {
       if (statSync(full).isDirectory()) {

--- a/src/harness/skill-registry.test.ts
+++ b/src/harness/skill-registry.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { type Registry, searchRegistry } from "./skill-registry.js";
+import {
+  installSkill,
+  PERMISSIVE_LICENSES,
+  type Registry,
+  type RegistrySkill,
+  searchRegistry,
+} from "./skill-registry.js";
 
 const TEST_REGISTRY: Registry = {
   skills: [
@@ -57,4 +63,55 @@ test("searchRegistry returns all matching skills", () => {
   // Both have "a" in author, but searchRegistry searches name/description/tags
   // "deploy app" matches "a" in description, so at least deploy
   assert.ok(results.length >= 1);
+});
+
+// ── Install gates ──
+
+const baseSkill: RegistrySkill = {
+  name: "test-skill",
+  description: "x",
+  author: "a",
+  version: "1",
+  source: "https://example.invalid/skill.md",
+  tags: [],
+};
+
+test("installSkill refuses link-only entries (installable: false)", async () => {
+  const skill: RegistrySkill = {
+    ...baseSkill,
+    installable: false,
+    license: "CC-BY-SA-4.0",
+    upstream: "https://example.com/x",
+  };
+  const result = await installSkill(skill);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "not-installable");
+    assert.ok(result.message.includes("CC-BY-SA-4.0"));
+    assert.ok(result.message.includes("https://example.com/x"));
+  }
+});
+
+test("installSkill refuses non-permissive license without --accept-license", async () => {
+  const skill: RegistrySkill = { ...baseSkill, license: "GPL-3.0" };
+  const result = await installSkill(skill);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "license-not-accepted");
+    assert.ok(result.message.includes("--accept-license=GPL-3.0"));
+  }
+});
+
+test("installSkill refuses license mismatch on --accept-license", async () => {
+  const skill: RegistrySkill = { ...baseSkill, license: "GPL-3.0" };
+  const result = await installSkill(skill, { acceptLicense: "MIT" });
+  assert.equal(result.ok, false);
+});
+
+test("PERMISSIVE_LICENSES contains the standard set", () => {
+  for (const id of ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "CC0-1.0"]) {
+    assert.ok(PERMISSIVE_LICENSES.has(id), `missing ${id}`);
+  }
+  assert.equal(PERMISSIVE_LICENSES.has("GPL-3.0"), false);
+  assert.equal(PERMISSIVE_LICENSES.has("CC-BY-SA-4.0"), false);
 });

--- a/src/harness/skill-registry.ts
+++ b/src/harness/skill-registry.ts
@@ -9,6 +9,17 @@ import { join } from "node:path";
 const DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/zhijiewong/openharness/main/data/registry.json";
 const GLOBAL_SKILLS_DIR = join(homedir(), ".oh", "skills");
 
+/** SPDX identifiers for licenses we install without explicit user acceptance. */
+export const PERMISSIVE_LICENSES = new Set([
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "CC0-1.0",
+  "Unlicense",
+]);
+
 export type RegistrySkill = {
   name: string;
   description: string;
@@ -16,6 +27,14 @@ export type RegistrySkill = {
   version: string;
   source: string; // URL to raw .md file
   tags: string[];
+  /** SPDX license identifier (e.g. "MIT"). Required for new entries; absent for legacy. */
+  license?: string;
+  /** Attribution string to preserve when installing (e.g. "© 2025 Jesse Vincent"). */
+  attribution?: string;
+  /** Upstream homepage / repo URL. */
+  upstream?: string;
+  /** When false, skill cannot be installed via this command — only linked to upstream. Used for viral licenses (CC-BY-SA, GPL). */
+  installable?: boolean;
 };
 
 export type Registry = {
@@ -40,15 +59,55 @@ export function searchRegistry(registry: Registry, query: string): RegistrySkill
   );
 }
 
-/** Install a skill from the registry to ~/.oh/skills/ */
-export async function installSkill(skill: RegistrySkill): Promise<string> {
+/** Result returned by installSkill — either success with path, or refusal with reason. */
+export type InstallResult =
+  | { ok: true; filePath: string }
+  | { ok: false; reason: "not-installable" | "license-not-accepted"; message: string };
+
+/** Install a skill from the registry to ~/.oh/skills/.
+ * Refuses non-permissive licenses unless `acceptLicense` matches the entry's license.
+ * Refuses entries with `installable: false` (e.g. viral-license skills that must be installed upstream).
+ */
+export async function installSkill(
+  skill: RegistrySkill,
+  opts: { acceptLicense?: string } = {},
+): Promise<InstallResult> {
+  // Gate 1: link-only entries
+  if (skill.installable === false) {
+    const upstream = skill.upstream ? ` Visit ${skill.upstream} to install under its license terms.` : "";
+    return {
+      ok: false,
+      reason: "not-installable",
+      message: `Skill "${skill.name}" is link-only (license: ${skill.license ?? "unknown"}).${upstream}`,
+    };
+  }
+
+  // Gate 2: license check
+  if (skill.license && !PERMISSIVE_LICENSES.has(skill.license)) {
+    if (opts.acceptLicense !== skill.license) {
+      return {
+        ok: false,
+        reason: "license-not-accepted",
+        message:
+          `Skill "${skill.name}" is licensed under ${skill.license}, which is not in the auto-install allowlist.\n` +
+          `To install, re-run with --accept-license=${skill.license} to acknowledge its terms.`,
+      };
+    }
+  }
+
   const response = await fetch(skill.source);
   if (!response.ok) throw new Error(`Failed to download skill: ${response.status}`);
-  const content = await response.text();
+  let content = await response.text();
+
+  // Preserve attribution by prepending an HTML comment if present and not already in the file
+  if (skill.attribution && !content.includes(skill.attribution)) {
+    const header = `<!-- Source: ${skill.upstream ?? skill.source}\n     License: ${skill.license ?? "unknown"}\n     ${skill.attribution} -->\n`;
+    content = header + content;
+  }
 
   mkdirSync(GLOBAL_SKILLS_DIR, { recursive: true });
   const slug = skill.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
   const filePath = join(GLOBAL_SKILLS_DIR, `${slug}.md`);
   writeFileSync(filePath, content);
-  return filePath;
+  return { ok: true, filePath };
 }

--- a/src/tools/MonitorTool/index.ts
+++ b/src/tools/MonitorTool/index.ts
@@ -89,7 +89,11 @@ export const MonitorTool: Tool<typeof inputSchema> = {
         for (const line of parts) handleLine(line);
       });
 
-      proc.on("exit", (code) => {
+      // Use "close" rather than "exit": "exit" can fire before stdout data
+      // has been fully drained on fast-exiting commands, causing CI flakiness
+      // where output appears empty. "close" is guaranteed to fire after all
+      // stdio streams have closed.
+      proc.on("close", (code) => {
         if (!settled) {
           settled = true;
           clearTimeout(timer);


### PR DESCRIPTION
## Summary

Aligns OpenHarness with the external plugin/skill/agent format ecosystem so artifacts authored for Anthropic's Claude Code, the superpowers plugin, Trail of Bits, and HKUDS/CLI-Anything all work in OH. Tier 4 of a phased plan documented at `docs/ecosystem-compat.md`.

- **Skills** — Anthropic kebab-case frontmatter aliases (`allowed-tools`, `disable-model-invocation`, `argument-hint`, `when-to-use`); new fields `license`, `paths`, `context`, `agent`. Directory-packaged layout (`skill-name/SKILL.md` + companion docs). 7 bundled skills loaded from the package itself; `/skills` command to list them.
- **Plugins** — `.claude-plugin/plugin.json` manifest auto-discovered from `~/.oh/plugins/cache/`. `.claude-plugin/marketplace.json` parsed alongside OH-native marketplace.json. Plugin-shipped `.mcp.json`, `hooks/hooks.json`, `.lsp.json` exposed via discovery helpers.
- **Agents** — `AgentRole` gains `model`, `disallowedTools`, `isolation`, `mcpServers`, `hooks`. `.claude/agents/` discovered alongside `.oh/agents/`. Tools field accepts both YAML array and space-/comma-separated string.
- **License hygiene** — `/skill-install` gates non-permissive SPDX licenses behind `--accept-license=<id>`; `installable: false` registry entries are link-only (used for CC-BY-SA content).
- **Registry** — expanded from 4 → 23 entries: 7 OH-native MIT, 8 superpowers MIT, 6 CLI-Anything Apache-2.0, 2 Trail-of-Bits CC-BY-SA (link-only). Each entry now declares license + attribution + upstream.

Anthropic's proprietary `anthropics/skills` is intentionally excluded — its LICENSE.txt forbids redistribution and OH user retention. See `docs/ecosystem-compat.md` for the full matrix and the list of items parsed-but-not-yet-runtime-wired.

## Stats

- **+46 tests** (890 → 936); 1 pre-existing `SessionSearchTool` failure unrelated to this branch (verified by stashing the branch and re-running)
- **5 commits** (Sessions 1-4)
- Typecheck + lint clean throughout

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [x] `npm test` — 935/936 pass (the 1 failure is `SessionSearchTool — returns no results for empty DB`, pre-existing on `main`)
- [x] `oh /skills` shows 7 bundled skills tagged `[bundled]`
- [x] Drop a real CC plugin layout (e.g. clone `obra/superpowers` into `~/.oh/plugins/cache/superpowers/5.0.7/`) and confirm `/plugin list` surfaces it with manifest fields
- [x] `/skill-install <name>` for an MIT registry entry succeeds; for the CC-BY-SA Trail-of-Bits entries, refusal message points to upstream
- [x] Smoke-test `oh remote -p 4567` and `oh mcp-server` to confirm no regressions in the existing surfaces