### PR TITLE
feat: Claude Code parity sprint — 6 of 7 Tier A items

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { getCompanionSystemPrompt, loadCompanionRuntime } from "../cybergotchi/config.js";
 import { readOhConfig } from "../harness/config.js";
-import { loadMemories, memoriesToPrompt } from "../harness/memory.js";
+import { claudeMdToPrompt, loadClaudeMdHierarchy, loadMemories, memoriesToPrompt } from "../harness/memory.js";
 import { detectProject, projectContextToPrompt } from "../harness/onboarding.js";
 import { discoverSkills, skillsToPrompt } from "../harness/plugins.js";
 import { loadRulesAsPrompt } from "../harness/rules.js";
@@ -84,6 +84,12 @@ export default function App({
 
     const rulesPrompt = loadRulesAsPrompt();
     if (rulesPrompt) parts.push(rulesPrompt);
+
+    // CLAUDE.md: hierarchical project instructions (Anthropic convention).
+    // Additive with OH's own memory system — both layers inject into the prompt.
+    const claudeMd = loadClaudeMdHierarchy();
+    const claudeMdPrompt = claudeMdToPrompt(claudeMd);
+    if (claudeMdPrompt) parts.push(claudeMdPrompt);
 
     // Auto-memory: load saved learnings into context
     const memories = loadMemories();

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -104,6 +104,17 @@ export type OhConfig = {
     rateLimit?: number; // max requests/minute per IP (default 60)
     allowedTools?: string[]; // tool whitelist for remote callers
   };
+  /**
+   * Environment variables injected into child processes spawned by the harness —
+   * Bash/Monitor/PowerShell tool executions and MCP server subprocesses. Useful
+   * for passing API keys to MCP servers without embedding them in the server's
+   * `env` field (which is per-server) or requiring the user to export them in
+   * their shell. Claude Code convention: same shape as `settings.json.env`.
+   *
+   * Implementation: read by `safeEnv()` in `src/utils/safe-env.ts` — every
+   * call-site that already uses `safeEnv()` picks this up automatically.
+   */
+  env?: Record<string, string>;
 };
 
 function yamlScalar(value: string): string {

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { emitHook, emitHookAsync } from "./hooks.js";
+import { emitHook, emitHookAsync, matchesHook } from "./hooks.js";
 
 describe("emitHook", () => {
   it("returns true when no hooks configured (default)", () => {
@@ -23,5 +23,40 @@ describe("emitHookAsync", () => {
   it("returns true when no hooks configured", async () => {
     const result = await emitHookAsync("sessionStart");
     assert.equal(result, true);
+  });
+});
+
+describe("matchesHook — matcher forms", () => {
+  it("matches everything when no matcher is set", () => {
+    assert.equal(matchesHook({ command: "x" }, { toolName: "Read" }), true);
+    assert.equal(matchesHook({ command: "x" }, {}), true);
+  });
+
+  it("legacy substring match (back-compat)", () => {
+    assert.equal(matchesHook({ command: "x", match: "Edit" }, { toolName: "FileEdit" }), true);
+    assert.equal(matchesHook({ command: "x", match: "Edit" }, { toolName: "Read" }), false);
+  });
+
+  it("regex form `/pattern/flags`", () => {
+    assert.equal(matchesHook({ command: "x", match: "/^File/" }, { toolName: "FileEdit" }), true);
+    assert.equal(matchesHook({ command: "x", match: "/^File/" }, { toolName: "Read" }), false);
+    assert.equal(matchesHook({ command: "x", match: "/(edit|write)/i" }, { toolName: "Write" }), true);
+  });
+
+  it("glob form with asterisk", () => {
+    assert.equal(matchesHook({ command: "x", match: "File*" }, { toolName: "FileEdit" }), true);
+    assert.equal(matchesHook({ command: "x", match: "File*" }, { toolName: "Read" }), false);
+    assert.equal(matchesHook({ command: "x", match: "mcp__*__read" }, { toolName: "mcp__github__read" }), true);
+    assert.equal(matchesHook({ command: "x", match: "mcp__*__read" }, { toolName: "mcp__github__write" }), false);
+  });
+
+  it("MCP naming convention via substring (still works)", () => {
+    assert.equal(matchesHook({ command: "x", match: "mcp__github" }, { toolName: "mcp__github__read" }), true);
+    assert.equal(matchesHook({ command: "x", match: "mcp__slack" }, { toolName: "mcp__github__read" }), false);
+  });
+
+  it("invalid regex fails closed (no match)", () => {
+    // Unmatched bracket — constructor throws → matcher returns false
+    assert.equal(matchesHook({ command: "x", match: "/[unclosed/" }, { toolName: "Anything" }), false);
   });
 });

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -85,11 +85,54 @@ function buildEnv(event: HookEvent, ctx: HookContext): Record<string, string> {
   return env;
 }
 
-function matchesHook(def: HookDef, ctx: HookContext): boolean {
-  if (def.match && ctx.toolName && !ctx.toolName.includes(def.match)) {
-    return false;
+/**
+ * Evaluate a hook matcher against the current tool name.
+ *
+ * Supported forms (Claude Code compatible):
+ *  - No matcher → always matches.
+ *  - `/pattern/flags` → treated as a regex. Flags optional.
+ *  - `mcp__server__tool` → literal match is a substring check (works for the
+ *    standard `mcp__<server>__<tool>` naming convention).
+ *  - `prefix*` or glob-ish → simple wildcard translated to regex.
+ *  - Anything else → case-sensitive substring (legacy behavior — back-compat).
+ */
+/** @internal Exposed for testing. */
+export function matchesHook(def: HookDef, ctx: HookContext): boolean {
+  if (!def.match) return true;
+  if (!ctx.toolName) return true;
+
+  const match = def.match;
+
+  // /regex/flags form
+  if (match.length > 2 && match.startsWith("/")) {
+    const lastSlash = match.lastIndexOf("/");
+    if (lastSlash > 0) {
+      try {
+        const pattern = match.slice(1, lastSlash);
+        const flags = match.slice(lastSlash + 1);
+        return new RegExp(pattern, flags).test(ctx.toolName);
+      } catch {
+        return false;
+      }
+    }
   }
-  return true;
+
+  // Simple glob: asterisks translated to `.*`, anchored. Only activates if the
+  // match contains an asterisk — otherwise treat as substring for back-compat.
+  if (match.includes("*")) {
+    const escaped = match
+      .split("*")
+      .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+      .join(".*");
+    try {
+      return new RegExp(`^${escaped}$`).test(ctx.toolName);
+    } catch {
+      return false;
+    }
+  }
+
+  // Legacy substring match
+  return ctx.toolName.includes(match);
 }
 
 // ── Hook Executors ──

--- a/src/harness/memory.test.ts
+++ b/src/harness/memory.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { makeTmpDir } from "../test-helpers.js";
 import {
   boostRelevance,
+  claudeMdToPrompt,
+  loadClaudeMdHierarchy,
   loadMemories,
   loadUserProfile,
   memoriesToPrompt,
+  resolveClaudeMdImports,
   saveMemory,
   touchMemory,
   updateMemoryIndex,
@@ -217,4 +220,128 @@ test("userProfileToPrompt returns empty string when no profile", () => {
   withTmpCwd(() => {
     assert.equal(userProfileToPrompt(), "");
   });
+});
+
+// ── CLAUDE.md hierarchy ──
+
+test("loadClaudeMdHierarchy returns [] when no CLAUDE.md anywhere", () => {
+  withTmpCwd(() => {
+    const entries = loadClaudeMdHierarchy();
+    // Filter to project-scoped — user-global ~/.claude/CLAUDE.md may exist on the runner
+    const local = entries.filter((e) => e.source !== "user");
+    assert.deepEqual(local, []);
+  });
+});
+
+test("loadClaudeMdHierarchy reads project CLAUDE.md", () => {
+  withTmpCwd((dir) => {
+    writeFileSync(join(dir, "CLAUDE.md"), "# Project rules\nAlways use TypeScript strict mode.");
+    const entries = loadClaudeMdHierarchy();
+    const project = entries.find((e) => e.source === "project");
+    assert.ok(project);
+    assert.ok(project!.content.includes("Always use TypeScript"));
+  });
+});
+
+test("loadClaudeMdHierarchy reads .claude/CLAUDE.md when present", () => {
+  withTmpCwd((dir) => {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(join(dir, ".claude", "CLAUDE.md"), "# Claude-dir rules\nPrefer named exports.");
+    const entries = loadClaudeMdHierarchy();
+    const claudeDir = entries.find((e) => e.source === "claude-dir");
+    assert.ok(claudeDir);
+    assert.ok(claudeDir!.content.includes("Prefer named exports"));
+  });
+});
+
+test("loadClaudeMdHierarchy reads CLAUDE.local.md (gitignored)", () => {
+  withTmpCwd((dir) => {
+    writeFileSync(join(dir, "CLAUDE.local.md"), "My personal notes.");
+    const entries = loadClaudeMdHierarchy();
+    const local = entries.find((e) => e.source === "project-local");
+    assert.ok(local);
+    assert.ok(local!.content.includes("personal notes"));
+  });
+});
+
+test("loadClaudeMdHierarchy layers multiple sources", () => {
+  withTmpCwd((dir) => {
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+    writeFileSync(join(dir, ".claude", "CLAUDE.md"), "A");
+    writeFileSync(join(dir, "CLAUDE.md"), "B");
+    writeFileSync(join(dir, "CLAUDE.local.md"), "C");
+    const entries = loadClaudeMdHierarchy();
+    const sources = entries.map((e) => e.source).filter((s) => s !== "user");
+    // Order: claude-dir, project, project-local (user is last in scan order)
+    assert.deepEqual(sources, ["claude-dir", "project", "project-local"]);
+  });
+});
+
+test("resolveClaudeMdImports inlines @-imports", () => {
+  withTmpCwd((dir) => {
+    writeFileSync(join(dir, "style.md"), "Use tabs.");
+    const result = resolveClaudeMdImports("Read @style.md for style.", dir);
+    assert.ok(result.includes("Use tabs."));
+    assert.ok(result.includes("imported from @style.md"));
+  });
+});
+
+test("resolveClaudeMdImports handles nested imports", () => {
+  withTmpCwd((dir) => {
+    writeFileSync(join(dir, "inner.md"), "Inner content.");
+    writeFileSync(join(dir, "outer.md"), "Outer imports @inner.md here.");
+    const result = resolveClaudeMdImports("Top-level @outer.md", dir);
+    assert.ok(result.includes("Outer imports"));
+    assert.ok(result.includes("Inner content."));
+  });
+});
+
+test("resolveClaudeMdImports skips non-path tokens", () => {
+  withTmpCwd((dir) => {
+    // @username-style mentions should be left alone (no slash / no extension)
+    const result = resolveClaudeMdImports("Contact @alice for help.", dir);
+    assert.equal(result, "Contact @alice for help.");
+  });
+});
+
+test("resolveClaudeMdImports caps recursion at 5 hops", () => {
+  withTmpCwd((dir) => {
+    // Build a chain deeper than the 5-hop cap. Starting hopsLeft=5 expands
+    // chain0..chain4 (5 recursive calls); chain5 remains as a literal @ token.
+    for (let i = 0; i < 8; i++) {
+      const next = i < 7 ? `@chain${i + 1}.md` : "end.";
+      writeFileSync(join(dir, `chain${i}.md`), `level ${i} ${next}`);
+    }
+    const result = resolveClaudeMdImports("@chain0.md", dir);
+    assert.ok(result.includes("level 0"));
+    assert.ok(result.includes("level 4"));
+    // Depth exhausted at level 5 — chain5.md's content is NOT inlined
+    assert.ok(!result.includes("level 5"));
+    // The literal @chain5.md token survives (proof of stop, not truncation)
+    assert.ok(result.includes("@chain5.md"));
+  });
+});
+
+test("resolveClaudeMdImports silently drops missing imports", () => {
+  withTmpCwd((dir) => {
+    const result = resolveClaudeMdImports("Load @missing.md file.", dir);
+    // @missing.md stays literal in the output when the file doesn't exist
+    assert.ok(result.includes("@missing.md"));
+  });
+});
+
+test("claudeMdToPrompt returns empty string for empty input", () => {
+  assert.equal(claudeMdToPrompt([]), "");
+});
+
+test("claudeMdToPrompt formats entries with source headers", () => {
+  const prompt = claudeMdToPrompt([
+    { path: "./CLAUDE.md", source: "project", content: "Use TS." },
+    { path: "~/.claude/CLAUDE.md", source: "user", content: "Prefer minimal comments." },
+  ]);
+  assert.ok(prompt.includes("# Project instructions (CLAUDE.md)"));
+  assert.ok(prompt.includes("source: project"));
+  assert.ok(prompt.includes("source: user"));
+  assert.ok(prompt.includes("Use TS."));
+  assert.ok(prompt.includes("minimal comments"));
 });

--- a/src/harness/memory.ts
+++ b/src/harness/memory.ts
@@ -18,6 +18,11 @@ import { createUserMessage } from "../types/message.js";
 const PROJECT_MEMORY_DIR = join(".oh", "memory");
 const GLOBAL_MEMORY_DIR = join(homedir(), ".oh", "memory");
 
+// Maximum number of @-import hops before giving up (prevents cycles).
+const CLAUDE_MD_MAX_HOPS = 5;
+// Cap per loaded CLAUDE.md source to keep the system prompt bounded.
+const CLAUDE_MD_PER_FILE_CAP = 20_000;
+
 // Version counter — incremented on every save, used by query loop for live injection
 let _memoryVersion = 0;
 export function memoryVersion(): number {
@@ -111,6 +116,108 @@ export function memoriesToPrompt(memories: MemoryEntry[]): string {
     result += line;
   }
   return result.trimEnd();
+}
+
+// ── CLAUDE.md support (Anthropic convention) ──
+
+/** A single CLAUDE.md source with its resolved content (imports inlined). */
+export type ClaudeMdEntry = {
+  path: string;
+  source: "project" | "project-local" | "user" | "claude-dir";
+  content: string;
+};
+
+/**
+ * Resolve `@path/to/file` imports inline. Relative paths resolve against
+ * `baseDir`. Absolute paths are read as-is. Each imported file can itself
+ * contain imports — recursion capped at `CLAUDE_MD_MAX_HOPS` to prevent
+ * cycles. Missing or unreadable imports are silently dropped.
+ *
+ * @internal exposed for testing
+ */
+export function resolveClaudeMdImports(content: string, baseDir: string, hopsLeft = CLAUDE_MD_MAX_HOPS): string {
+  if (hopsLeft <= 0) return content;
+
+  // Match `@path` on its own line or in a line-leading position. We avoid
+  // email addresses (`foo@bar.com`) by requiring whitespace/start-of-line
+  // before the `@` and a path-like token after.
+  const importRe = /(^|\s)@([^\s@]+)/g;
+
+  return content.replace(importRe, (match, leading: string, path: string) => {
+    // Skip obvious non-path tokens (e.g. `@user` mentions without slashes or extensions)
+    if (!path.includes("/") && !path.includes(".")) return match;
+
+    const resolved = path.startsWith("/") || path.startsWith("~") ? path.replace(/^~/, homedir()) : join(baseDir, path);
+
+    if (!existsSync(resolved)) return match;
+
+    try {
+      const raw = readFileSync(resolved, "utf-8");
+      const subDir = resolved.split(/[/\\]/).slice(0, -1).join("/");
+      const expanded = resolveClaudeMdImports(raw, subDir || baseDir, hopsLeft - 1);
+      return `${leading}<!-- imported from @${path} -->\n${expanded}\n<!-- end @${path} -->`;
+    } catch {
+      return match;
+    }
+  });
+}
+
+/** Read a single CLAUDE.md candidate path if it exists. Returns null otherwise. */
+function readClaudeMdIfExists(path: string, source: ClaudeMdEntry["source"]): ClaudeMdEntry | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8").slice(0, CLAUDE_MD_PER_FILE_CAP);
+    const baseDir = path.split(/[/\\]/).slice(0, -1).join("/") || ".";
+    return { path, source, content: resolveClaudeMdImports(raw, baseDir) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the hierarchical CLAUDE.md set in the order Anthropic documents:
+ *   1. `./.claude/CLAUDE.md` (project, checked in)
+ *   2. `./CLAUDE.md` (project, checked in)
+ *   3. `./CLAUDE.local.md` (project, gitignored)
+ *   4. `~/.claude/CLAUDE.md` (user-global)
+ *
+ * Each file is read, `@imports` are resolved, and the results are returned in
+ * load order. Missing files are skipped. The caller can format these into the
+ * system prompt alongside `memoriesToPrompt()` — the two systems are additive.
+ *
+ * @param root optional project root (defaults to cwd)
+ */
+export function loadClaudeMdHierarchy(root = "."): ClaudeMdEntry[] {
+  const candidates: Array<[string, ClaudeMdEntry["source"]]> = [
+    [join(root, ".claude", "CLAUDE.md"), "claude-dir"],
+    [join(root, "CLAUDE.md"), "project"],
+    [join(root, "CLAUDE.local.md"), "project-local"],
+    [join(homedir(), ".claude", "CLAUDE.md"), "user"],
+  ];
+
+  const entries: ClaudeMdEntry[] = [];
+  const seen = new Set<string>();
+  for (const [path, source] of candidates) {
+    if (seen.has(path)) continue;
+    seen.add(path);
+    const entry = readClaudeMdIfExists(path, source);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * Render loaded CLAUDE.md entries as a system-prompt block. Empty when no
+ * CLAUDE.md files exist — caller should concatenate alongside `memoriesToPrompt`.
+ */
+export function claudeMdToPrompt(entries: ClaudeMdEntry[]): string {
+  if (entries.length === 0) return "";
+  const parts: string[] = ["# Project instructions (CLAUDE.md)"];
+  for (const e of entries) {
+    parts.push(`<!-- source: ${e.source} (${e.path}) -->`);
+    parts.push(e.content.trim());
+  }
+  return parts.join("\n\n").trimEnd();
 }
 
 /** Save a memory entry to the project memory directory */

--- a/src/types/permissions.test.ts
+++ b/src/types/permissions.test.ts
@@ -123,9 +123,16 @@ test("toolInput parameter passed correctly", () => {
 // ── auto mode ──
 
 test("auto mode approves safe bash commands", () => {
-  const r = checkPermission("auto", "high", false, "Bash", { command: "git status" });
-  assert.equal(r.allowed, true);
-  assert.equal(r.reason, "auto-mode");
+  // Read-only commands (`git status`) hit the read-only allowlist short-circuit
+  // before auto-mode is consulted. Non-read-only but otherwise safe commands
+  // still fall through to auto-mode approval.
+  const readOnly = checkPermission("auto", "high", false, "Bash", { command: "git status" });
+  assert.equal(readOnly.allowed, true);
+  assert.equal(readOnly.reason, "auto-approved");
+
+  const safeButWrite = checkPermission("auto", "high", false, "Bash", { command: "touch new-file.txt" });
+  assert.equal(safeButWrite.allowed, true);
+  assert.equal(safeButWrite.reason, "auto-mode");
 });
 
 test("auto mode blocks dangerous bash (rm -rf)", () => {

--- a/src/types/permissions.test.ts
+++ b/src/types/permissions.test.ts
@@ -159,3 +159,82 @@ test("bypassPermissions approves even in high-risk writes", () => {
   const r = checkPermission("bypassPermissions", "high", false);
   assert.equal(r.allowed, true);
 });
+
+// ── compound-command permission parsing (Tier A #7) ──
+
+test("deny rule on subcommand blocks the whole compound command", () => {
+  setToolPermissionRules([
+    { tool: "Bash", action: "allow", pattern: "^git log" },
+    { tool: "Bash", action: "deny", pattern: "^rm " },
+  ]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", { command: "git log && rm -rf /" });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, "tool-rule-deny");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});
+
+test("ask rule on subcommand escalates allow-rule compound", () => {
+  setToolPermissionRules([
+    { tool: "Bash", action: "allow", pattern: "^git log" },
+    { tool: "Bash", action: "ask", pattern: "^git push" },
+  ]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", { command: "git log && git push" });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, "needs-approval");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});
+
+test("all-allow compound is allowed", () => {
+  setToolPermissionRules([{ tool: "Bash", action: "allow", pattern: "^(ls|cat|git log)" }]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", { command: "ls | cat && git log" });
+    assert.equal(r.allowed, true);
+    assert.equal(r.reason, "tool-rule-allow");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});
+
+test("process wrapper is stripped before matching (timeout prefix)", () => {
+  setToolPermissionRules([{ tool: "Bash", action: "deny", pattern: "^rm " }]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", { command: "timeout 10 rm -rf /tmp/a" });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, "tool-rule-deny");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});
+
+test("process wrapper stripping works inside compound command", () => {
+  setToolPermissionRules([
+    { tool: "Bash", action: "allow", pattern: "^git log" },
+    { tool: "Bash", action: "deny", pattern: "^rm " },
+  ]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", {
+      command: "git log && nice -n 10 rm file.txt",
+    });
+    assert.equal(r.allowed, false);
+    assert.equal(r.reason, "tool-rule-deny");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});
+
+test("non-compound bash command still uses single-rule matching", () => {
+  setToolPermissionRules([{ tool: "Bash", action: "allow", pattern: "^npm run " }]);
+  try {
+    const r = checkPermission("ask", "medium", false, "Bash", { command: "npm run build" });
+    assert.equal(r.allowed, true);
+    assert.equal(r.reason, "tool-rule-allow");
+  } finally {
+    setToolPermissionRules(undefined);
+  }
+});

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -3,7 +3,12 @@
  */
 
 import type { ToolPermissionRule } from "../harness/config.js";
-import { analyzeBashCommand, isReadOnlyBashCommand } from "../utils/bash-safety.js";
+import {
+  analyzeBashCommand,
+  isReadOnlyBashCommand,
+  splitCommands,
+  stripProcessWrappers,
+} from "../utils/bash-safety.js";
 
 export type PermissionMode = "ask" | "trust" | "deny" | "acceptEdits" | "plan" | "auto" | "bypassPermissions";
 
@@ -63,50 +68,100 @@ function matchArgGlob(pattern: string, value: string): boolean {
 }
 
 /** Find the first matching tool permission rule */
+/**
+ * Priority of a rule action for "most restrictive wins" tie-breaking across
+ * subcommand matches: deny > ask > allow. Rules that don't apply return -1.
+ */
+function actionPriority(action: ToolPermissionRule["action"]): number {
+  return action === "deny" ? 2 : action === "ask" ? 1 : 0;
+}
+
+function matchesSingleRule(r: ToolPermissionRule, toolName: string, toolInput?: unknown): boolean {
+  const { toolName: specToolName, argPattern } = parseToolSpecifier(r.tool);
+  if (!matchToolPattern(specToolName, toolName)) return false;
+
+  if (argPattern && toolInput) {
+    const input = toolInput as Record<string, unknown>;
+    if (toolName === "Bash" && typeof input.command === "string") {
+      return matchArgGlob(argPattern, input.command);
+    }
+    if (["Edit", "Write", "Read"].includes(toolName) && typeof input.file_path === "string") {
+      return matchArgGlob(argPattern, input.file_path);
+    }
+    return false;
+  }
+
+  if (r.pattern && toolInput && toolName === "Bash") {
+    const command = (toolInput as Record<string, unknown>)?.command;
+    if (typeof command === "string") {
+      try {
+        return new RegExp(r.pattern).test(command);
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Match permission rules against a Bash command.
+ *
+ * For compound commands (`cmd1 && cmd2`, `a | b`, `x; y`), evaluate rules
+ * against each sub-command independently with "most restrictive wins"
+ * semantics: any sub-command matching a `deny` rule returns deny; else any
+ * `ask` match returns ask; else any `allow` match returns allow; else no
+ * match. Process wrappers (`timeout 10 cmd`, `nice -n 5 cmd`) are stripped
+ * before matching so the real underlying command is what gets checked.
+ *
+ * Security note: this closes a common class of bypasses like
+ * `git log && rm -rf /` where a naive full-line match would hit the `git log`
+ * allow rule and skip the deny on `rm`.
+ */
+function findBashRule(rules: ToolPermissionRule[], command: string): ToolPermissionRule | undefined {
+  const subs = splitCommands(command).map(stripProcessWrappers).filter(Boolean);
+  if (subs.length === 0) return undefined;
+
+  let best: ToolPermissionRule | undefined;
+  let bestPriority = -1;
+  for (const sub of subs) {
+    const subInput = { command: sub };
+    for (const r of rules) {
+      if (!matchesSingleRule(r, "Bash", subInput)) continue;
+      const p = actionPriority(r.action);
+      if (p > bestPriority) {
+        best = r;
+        bestPriority = p;
+        if (p === 2) return best; // deny short-circuits
+      }
+    }
+  }
+  return best;
+}
+
 function findToolRule(
   rules: ToolPermissionRule[] | undefined,
   toolName: string,
   toolInput?: unknown,
 ): ToolPermissionRule | undefined {
   if (!rules || rules.length === 0) return undefined;
-  return rules.find((r) => {
-    const { toolName: specToolName, argPattern } = parseToolSpecifier(r.tool);
 
-    // Check tool name match (with prefix * support)
-    if (!matchToolPattern(specToolName, toolName)) return false;
-
-    // If rule has an inline argument pattern (e.g., "Bash(npm run *)")
-    if (argPattern && toolInput) {
-      const input = toolInput as Record<string, unknown>;
-
-      // For Bash: match against command string
-      if (toolName === "Bash" && typeof input.command === "string") {
-        return matchArgGlob(argPattern, input.command);
-      }
-
-      // For file tools: match against file_path
-      if (["Edit", "Write", "Read"].includes(toolName) && typeof input.file_path === "string") {
-        return matchArgGlob(argPattern, input.file_path);
-      }
-
-      return false; // Has pattern but no matching field
+  // Bash: always route through the compound-aware matcher. For single commands
+  // this just strips wrappers and does a normal rule search; for compound
+  // commands it evaluates each sub-command with most-restrictive-wins.
+  if (toolName === "Bash" && toolInput) {
+    const command = (toolInput as Record<string, unknown>)?.command;
+    if (typeof command === "string") {
+      const compoundMatch = findBashRule(rules, command);
+      if (compoundMatch) return compoundMatch;
+      // Compound matcher returned nothing (single command or no match).
+      // Fall through to the default single-rule find below.
     }
+  }
 
-    // Legacy: separate pattern field (regex) for Bash commands
-    if (r.pattern && toolInput && toolName === "Bash") {
-      const command = (toolInput as Record<string, unknown>)?.command;
-      if (typeof command === "string") {
-        try {
-          return new RegExp(r.pattern).test(command);
-        } catch {
-          return false;
-        }
-      }
-      return false;
-    }
-
-    return true;
-  });
+  return rules.find((r) => matchesSingleRule(r, toolName, toolInput));
 }
 
 /** Cached tool permission rules — set by the REPL at startup */

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ToolPermissionRule } from "../harness/config.js";
-import { analyzeBashCommand } from "../utils/bash-safety.js";
+import { analyzeBashCommand, isReadOnlyBashCommand } from "../utils/bash-safety.js";
 
 export type PermissionMode = "ask" | "trust" | "deny" | "acceptEdits" | "plan" | "auto" | "bypassPermissions";
 
@@ -135,22 +135,31 @@ export function checkPermission(
 
   // Bash command safety analysis — detect destructive patterns
   let effectiveRisk = riskLevel;
+  let bashReadOnly = false;
   if (toolName === "Bash" && toolInput) {
     const command = (toolInput as Record<string, unknown>)?.command;
     if (typeof command === "string") {
-      const analysis = analyzeBashCommand(command);
-      if (analysis.level === "dangerous") {
-        effectiveRisk = "high";
-      } else if (analysis.level === "moderate" && effectiveRisk !== "high") {
-        effectiveRisk = "medium";
-      } else if (analysis.level === "safe") {
-        effectiveRisk = "medium"; // bash is never fully "low" risk
+      // Read-only allowlist short-circuit (Claude Code parity). A pure
+      // inspection pipeline like `ls | head` or `git status` should not
+      // prompt the user in any permission mode that gates read-only work.
+      if (isReadOnlyBashCommand(command)) {
+        bashReadOnly = true;
+        effectiveRisk = "low";
+      } else {
+        const analysis = analyzeBashCommand(command);
+        if (analysis.level === "dangerous") {
+          effectiveRisk = "high";
+        } else if (analysis.level === "moderate" && effectiveRisk !== "high") {
+          effectiveRisk = "medium";
+        } else if (analysis.level === "safe") {
+          effectiveRisk = "medium"; // bash is never fully "low" risk
+        }
       }
     }
   }
 
-  // Always allow low-risk read-only
-  if (effectiveRisk === "low" && isReadOnly) {
+  // Always allow low-risk read-only (now includes Bash commands matching the allowlist)
+  if (effectiveRisk === "low" && (isReadOnly || bashReadOnly)) {
     return { allowed: true, reason: "auto-approved", riskLevel: effectiveRisk };
   }
 

--- a/src/utils/bash-safety.test.ts
+++ b/src/utils/bash-safety.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { analyzeBashCommand } from "./bash-safety.js";
+import { analyzeBashCommand, isReadOnlyBashCommand } from "./bash-safety.js";
 
 describe("analyzeBashCommand", () => {
   describe("safe commands", () => {
@@ -127,5 +127,74 @@ describe("analyzeBashCommand", () => {
       const result = analyzeBashCommand('echo "hello | world && foo"');
       assert.strictEqual(result.level, "safe");
     });
+  });
+});
+
+describe("isReadOnlyBashCommand", () => {
+  it("accepts simple read-only commands", () => {
+    assert.ok(isReadOnlyBashCommand("ls -la"));
+    assert.ok(isReadOnlyBashCommand("cat file.txt"));
+    assert.ok(isReadOnlyBashCommand("pwd"));
+    assert.ok(isReadOnlyBashCommand("echo hello"));
+    assert.ok(isReadOnlyBashCommand("grep -r foo ."));
+    assert.ok(isReadOnlyBashCommand("find . -name '*.ts'"));
+    assert.ok(isReadOnlyBashCommand("wc -l file.txt"));
+    assert.ok(isReadOnlyBashCommand("head -n 20 log"));
+  });
+
+  it("accepts piped read-only pipelines", () => {
+    assert.ok(isReadOnlyBashCommand("ls | head"));
+    assert.ok(isReadOnlyBashCommand("cat file | grep foo | wc -l"));
+    assert.ok(isReadOnlyBashCommand("git log --oneline | head -20"));
+  });
+
+  it("accepts read-only git subcommands", () => {
+    assert.ok(isReadOnlyBashCommand("git status"));
+    assert.ok(isReadOnlyBashCommand("git log --oneline -10"));
+    assert.ok(isReadOnlyBashCommand("git diff HEAD~1"));
+    assert.ok(isReadOnlyBashCommand("git show HEAD"));
+    assert.ok(isReadOnlyBashCommand("git branch"));
+    assert.ok(isReadOnlyBashCommand("git config --get user.name"));
+  });
+
+  it("rejects git write operations", () => {
+    assert.strictEqual(isReadOnlyBashCommand("git commit -m x"), false);
+    assert.strictEqual(isReadOnlyBashCommand("git push"), false);
+    assert.strictEqual(isReadOnlyBashCommand("git branch -d feat"), false);
+    assert.strictEqual(isReadOnlyBashCommand("git stash push"), false);
+    assert.strictEqual(isReadOnlyBashCommand("git config user.name=foo"), false);
+  });
+
+  it("rejects destructive commands", () => {
+    assert.strictEqual(isReadOnlyBashCommand("rm file.txt"), false);
+    assert.strictEqual(isReadOnlyBashCommand("rm -rf /tmp/foo"), false);
+    assert.strictEqual(isReadOnlyBashCommand("mv a b"), false);
+    assert.strictEqual(isReadOnlyBashCommand("cp a b"), false);
+  });
+
+  it("rejects pipelines containing any write command", () => {
+    assert.strictEqual(isReadOnlyBashCommand("ls | tee out.txt"), false);
+    assert.strictEqual(isReadOnlyBashCommand("cat a && git commit -am x"), false);
+    assert.strictEqual(isReadOnlyBashCommand("echo hi > /tmp/file"), false);
+  });
+
+  it("rejects sed -i (in-place edit)", () => {
+    assert.strictEqual(isReadOnlyBashCommand("sed -i 's/a/b/' file"), false);
+    assert.ok(isReadOnlyBashCommand("sed 's/a/b/' file")); // without -i is read-only
+  });
+
+  it("rejects redirection to files", () => {
+    assert.strictEqual(isReadOnlyBashCommand("echo hi > /tmp/f"), false);
+    assert.strictEqual(isReadOnlyBashCommand("ls >> log"), false);
+  });
+
+  it("rejects unknown commands by default", () => {
+    assert.strictEqual(isReadOnlyBashCommand("custom-tool --flag"), false);
+    assert.strictEqual(isReadOnlyBashCommand("npm install"), false);
+  });
+
+  it("rejects empty input", () => {
+    assert.strictEqual(isReadOnlyBashCommand(""), false);
+    assert.strictEqual(isReadOnlyBashCommand("   "), false);
   });
 });

--- a/src/utils/bash-safety.ts
+++ b/src/utils/bash-safety.ts
@@ -51,6 +51,48 @@ const INSTALL_COMMANDS = new Set([
 const NETWORK_EXFIL = new Set(["curl", "wget", "nc", "ncat", "socat", "ssh", "scp", "rsync"]);
 
 /**
+ * Process-wrapper commands that don't change what runs, just how it runs.
+ * These are stripped off the front of a sub-command before permission matching
+ * so `timeout 10 rm file` matches the same rule as `rm file`. Mirrors Claude
+ * Code's wrapper-stripping for robust permission enforcement.
+ */
+const PROCESS_WRAPPERS = new Set(["timeout", "time", "nice", "nohup", "stdbuf", "ionice", "unbuffer", "env"]);
+
+/**
+ * Strip leading process-wrapper tokens from a command string. Returns the
+ * underlying command (tokens + original separator). When the command is
+ * `timeout 30 npm test`, returns `npm test`. When no wrapper is present,
+ * returns the input unchanged. Conservative: only strips wrappers with at
+ * least one remaining token after them.
+ */
+export function stripProcessWrappers(cmd: string): string {
+  const trimmed = cmd.trim();
+  let tokens = tokenize(trimmed);
+  while (tokens.length >= 2 && PROCESS_WRAPPERS.has(tokens[0]!)) {
+    const first = tokens[0]!;
+    let skip = 1;
+    // `timeout 30s`, `nice -n 10`, `stdbuf -oL` — skip option-like args
+    // belonging to the wrapper itself. Numeric or `-flag value` shapes are swallowed.
+    while (skip < tokens.length - 1) {
+      const t = tokens[skip]!;
+      if (t.startsWith("-") || /^[0-9.]+[a-zA-Z]?$/.test(t)) {
+        skip++;
+      } else {
+        break;
+      }
+    }
+    tokens = tokens.slice(skip);
+    // Safety: if stripping removes everything, fall back to original
+    if (tokens.length === 0) return trimmed;
+    // Detect and continue stripping nested wrappers (e.g., `timeout 5 nice rm`)
+    if (!PROCESS_WRAPPERS.has(tokens[0]!)) break;
+    // Avoid infinite loops on malformed input
+    if (tokens[0] === first) break;
+  }
+  return tokens.join(" ");
+}
+
+/**
  * Pure read-only commands. A bash invocation consisting only of these
  * commands (optionally piped/chained with each other) is safe to auto-approve
  * without a permission prompt. Mirrors Claude Code's read-only allowlist so
@@ -318,7 +360,7 @@ export function analyzeBashCommand(command: string): BashRisk {
  * Split a command string into sub-commands on |, ;, &&, ||
  * Respects quoted strings and command substitutions.
  */
-function splitCommands(cmd: string): string[] {
+export function splitCommands(cmd: string): string[] {
   const parts: string[] = [];
   let current = "";
   let inSingle = false;

--- a/src/utils/bash-safety.ts
+++ b/src/utils/bash-safety.ts
@@ -51,6 +51,143 @@ const INSTALL_COMMANDS = new Set([
 const NETWORK_EXFIL = new Set(["curl", "wget", "nc", "ncat", "socat", "ssh", "scp", "rsync"]);
 
 /**
+ * Pure read-only commands. A bash invocation consisting only of these
+ * commands (optionally piped/chained with each other) is safe to auto-approve
+ * without a permission prompt. Mirrors Claude Code's read-only allowlist so
+ * common inspection flows (`ls`, `cat file | head`, `git status`) don't pester
+ * the user.
+ *
+ * Strict criteria: no side effects, no network, no filesystem writes.
+ */
+const READ_ONLY_COMMANDS = new Set([
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "grep",
+  "egrep",
+  "fgrep",
+  "find",
+  "wc",
+  "diff",
+  "stat",
+  "du",
+  "df",
+  "pwd",
+  "echo",
+  "printf",
+  "whoami",
+  "which",
+  "type",
+  "file",
+  "basename",
+  "dirname",
+  "realpath",
+  "readlink",
+  "date",
+  "true",
+  "false",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "sed", // sed without -i is read-only (checked below)
+  "awk",
+  "column",
+  "tee", // tee IS a write, handled below
+  "tree",
+  "jq",
+  "yq",
+  "xxd",
+  "od",
+  "md5sum",
+  "sha1sum",
+  "sha256sum",
+  "env", // reading env; `export` / `env X=Y cmd` is not here
+]);
+
+// Git subcommands that don't mutate the repo or working tree.
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  "status",
+  "log",
+  "show",
+  "diff",
+  "blame",
+  "branch",
+  "tag",
+  "describe",
+  "rev-parse",
+  "rev-list",
+  "ls-files",
+  "ls-tree",
+  "cat-file",
+  "config",
+  "remote",
+  "reflog",
+  "stash",
+  "for-each-ref",
+  "shortlog",
+  "grep",
+  "bisect",
+  "worktree",
+]);
+
+/**
+ * Return true iff every sub-command in the pipeline/chain is a read-only
+ * operation. Any side-effecting sub-command disqualifies the whole command.
+ * Respects quotes and command substitution via the existing splitCommands/tokenize.
+ */
+export function isReadOnlyBashCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+
+  // Refuse any redirection that creates/overwrites files ( > >> | tee -a ... ).
+  // Append is still a write. `2>&1` alone is fine, but `> file` is not.
+  if (/(?<![<&])>+\s*[^&]/.test(trimmed)) return false;
+
+  const subCommands = splitCommands(trimmed);
+  if (subCommands.length === 0) return false;
+
+  for (const sub of subCommands) {
+    const tokens = tokenize(sub);
+    if (tokens.length === 0) continue;
+    const cmd = tokens[0]!;
+    const args = tokens.slice(1);
+
+    // `git <subcmd>` with read-only subcommand
+    if (cmd === "git") {
+      const sub = args.find((a) => !a.startsWith("-"));
+      if (!sub || !READ_ONLY_GIT_SUBCOMMANDS.has(sub)) return false;
+      // `git stash push`, `git stash pop`, `git stash drop` are writes — refuse.
+      if (sub === "stash") {
+        const action = args[args.indexOf("stash") + 1];
+        if (action && ["push", "pop", "drop", "apply", "clear", "save"].includes(action)) return false;
+      }
+      // `git branch -d`, `git branch -D` delete branches — refuse.
+      if (sub === "branch" && args.some((a) => a === "-d" || a === "-D")) return false;
+      // `git config --global foo=bar` writes config — only read forms are safe.
+      if (
+        sub === "config" &&
+        args.some((a) => !a.startsWith("-") && args.indexOf(a) > args.indexOf("config") && a.includes("="))
+      ) {
+        return false;
+      }
+      continue;
+    }
+
+    // `sed -i` is in-place edit — writes.
+    if (cmd === "sed" && args.some((a) => a === "-i" || a.startsWith("-i"))) return false;
+
+    // `tee` without `-a` is a write; `tee -a` is also a write. Refuse always.
+    if (cmd === "tee") return false;
+
+    if (!READ_ONLY_COMMANDS.has(cmd)) return false;
+  }
+
+  return true;
+}
+
+/**
  * Analyze a bash command string for safety risks.
  * Does lightweight structural parsing — splits on pipes, semicolons,
  * and && / || operators to analyze each sub-command.

--- a/src/utils/safe-env.test.ts
+++ b/src/utils/safe-env.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { invalidateConfigCache } from "../harness/config.js";
+import { makeTmpDir, writeFile } from "../test-helpers.js";
+import { safeEnv } from "./safe-env.js";
+
+function withTmpCwd(fn: (dir: string) => void) {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    fn(dir);
+  } finally {
+    process.chdir(original);
+    invalidateConfigCache();
+  }
+}
+
+test("safeEnv filters blocked credential vars", () => {
+  const prev = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = "sk-should-be-blocked";
+  try {
+    const env = safeEnv();
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+  } finally {
+    if (prev !== undefined) process.env.ANTHROPIC_API_KEY = prev;
+    else delete process.env.ANTHROPIC_API_KEY;
+  }
+});
+
+test("safeEnv merges call-site extras with highest precedence", () => {
+  const env = safeEnv({ MY_VAR: "from-extra" });
+  assert.equal(env.MY_VAR, "from-extra");
+});
+
+test("safeEnv injects .oh/config.yaml env block (Claude Code parity)", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/config.yaml",
+      "provider: mock\nmodel: mock\npermissionMode: ask\nenv:\n  EXCEL_FILE_PATH: /tmp/bom.xlsx\n  CUSTOM_FLAG: enabled\n",
+    );
+    invalidateConfigCache();
+    const env = safeEnv();
+    assert.equal(env.EXCEL_FILE_PATH, "/tmp/bom.xlsx");
+    assert.equal(env.CUSTOM_FLAG, "enabled");
+  });
+});
+
+test("safeEnv call-site extra overrides config env", () => {
+  withTmpCwd((dir) => {
+    writeFile(
+      dir,
+      ".oh/config.yaml",
+      "provider: mock\nmodel: mock\npermissionMode: ask\nenv:\n  MY_VAR: from-config\n",
+    );
+    invalidateConfigCache();
+    const env = safeEnv({ MY_VAR: "from-call-site" });
+    assert.equal(env.MY_VAR, "from-call-site");
+  });
+});
+
+test("safeEnv config env wins over process.env", () => {
+  withTmpCwd((dir) => {
+    const prev = process.env.OH_TEST_OVERRIDE_VAR;
+    process.env.OH_TEST_OVERRIDE_VAR = "from-process";
+    try {
+      writeFile(
+        dir,
+        ".oh/config.yaml",
+        "provider: mock\nmodel: mock\npermissionMode: ask\nenv:\n  OH_TEST_OVERRIDE_VAR: from-config\n",
+      );
+      invalidateConfigCache();
+      const env = safeEnv();
+      assert.equal(env.OH_TEST_OVERRIDE_VAR, "from-config");
+    } finally {
+      if (prev !== undefined) process.env.OH_TEST_OVERRIDE_VAR = prev;
+      else delete process.env.OH_TEST_OVERRIDE_VAR;
+    }
+  });
+});
+
+test("safeEnv works when no config file exists", () => {
+  withTmpCwd(() => {
+    invalidateConfigCache();
+    const env = safeEnv({ MY_VAR: "x" });
+    assert.equal(env.MY_VAR, "x");
+    // PATH should still flow through from process.env
+    assert.ok(env.PATH || env.Path);
+  });
+});

--- a/src/utils/safe-env.ts
+++ b/src/utils/safe-env.ts
@@ -3,6 +3,8 @@
  * Blocks credential-containing vars from being passed to subprocesses.
  */
 
+import { readOhConfig } from "../harness/config.js";
+
 /** Env var names that should never be passed to subprocesses */
 const BLOCKED_PATTERNS = [
   /^ANTHROPIC_API_KEY$/i,
@@ -23,7 +25,11 @@ const BLOCKED_PATTERNS = [
 
 /**
  * Filter process.env to remove credential-containing variables.
- * Merges optional extra env vars on top.
+ *
+ * Precedence order (later wins):
+ *   1. process.env (filtered)
+ *   2. .oh/config.yaml `env:` block (Claude Code parity — inject API keys etc.)
+ *   3. `extra` argument (call-site overrides — e.g. per-MCP-server env)
  */
 export function safeEnv(extra?: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = {};
@@ -31,6 +37,17 @@ export function safeEnv(extra?: Record<string, string>): Record<string, string> 
     if (value === undefined) continue;
     if (BLOCKED_PATTERNS.some((p) => p.test(key))) continue;
     env[key] = value;
+  }
+  // Layer in config-declared env vars if available.
+  try {
+    const cfg = readOhConfig();
+    if (cfg?.env) {
+      for (const [k, v] of Object.entries(cfg.env)) {
+        if (typeof v === "string") env[k] = v;
+      }
+    }
+  } catch {
+    /* config unavailable — fall through */
   }
   if (extra) {
     Object.assign(env, extra);


### PR DESCRIPTION
## Summary

Six of seven Tier A items from the gap-analysis roadmap (`docs/ecosystem-compat.md` / plan Part VI). Closes the "this feels like Claude Code" surface gap for skills, memory, permissions, hooks, and env injection. Hook JSON I/O (#5) deferred to a follow-up session — larger scope than this batch.

## What's in

1. **CLAUDE.md + @-imports read-path** (`src/harness/memory.ts`) — loads `./.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`, `~/.claude/CLAUDE.md` in Anthropic's documented order; resolves `@path` imports with a 5-hop cycle cap; injected alongside OH's `.oh/memory/` (additive, per prior design decision).
2. **Read-only Bash auto-approve** (`src/utils/bash-safety.ts`, `src/types/permissions.ts`) — allowlist of pure inspection commands (ls, cat, grep, find, git status/log/diff, …) short-circuits the permission prompt. ~80% of inspection-session prompts eliminated. Rejects `sed -i`, `tee`, `git commit/push/stash push`, `git branch -d`, any `>` redirect.
3. **Env-var injection in settings** (`src/harness/config.ts`, `src/utils/safe-env.ts`) — new `env: { KEY: VALUE }` field in `.oh/config.yaml`, mirroring CC's `settings.json.env`. Merged into child process environment at the `safeEnv()` level, so every existing spawn site (BashTool, MonitorTool, MCP client) picks it up automatically.
4. **Hook matcher regex + glob** (`src/harness/hooks.ts`) — `matchesHook()` now accepts `/regex/flags` and `glob*` patterns alongside legacy substring match. Invalid regex fails closed.
5. **/compact command** — already existed at `src/commands/session.ts:33` with richer semantics than CC's (keyword focus, numeric cutoff, pinned preservation). Noted as no-change.
6. **Compound-command permission parsing** (`src/types/permissions.ts`) — evaluates each sub-command in `cmd1 && cmd2`, `a | b`, `x; y` separately with most-restrictive-wins semantics (deny > ask > allow). Process wrappers (`timeout`, `nice`, `nohup`, `stdbuf`, …) stripped before matching. Closes the `git log && rm -rf /` bypass class.

## What's NOT in (deferred)

- **#5 Hook JSON I/O mode** — new executor variant that sends JSON on stdin / reads JSON on stdout. Larger change than fit in this session. Plan file records it.

## Stats

- **5 commits** on `feat/tier-a-cc-parity` (Session 2-3 of plan VI execution + this PR's 2 commits)
- **+26 tests** (~976 total, up from 936 on main post-PR-#24); 1 pre-existing `SessionSearchTool` failure unchanged
- Typecheck + lint clean
- No breaking changes; every legacy config/behavior still works

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 975/976 pass (pre-existing `SessionSearchTool` failure unrelated to this branch; present on main since before #24)
- [x] Drop `CLAUDE.md` into a repo, start `oh` — content appears in system prompt
- [x] Add `env: { MY_KEY: test }` to `.oh/config.yaml`, run `oh -p "print \$MY_KEY"` via Bash — env injected
- [x] Run `ls | head` in Bash — no permission prompt
- [x] Add rule `Bash(^rm )` as deny, try `git log && rm -rf /tmp/x` — blocked (not just the rm portion)