### PR TITLE
chore: release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2.9.0 (2026-04-18) — Claude Code Ecosystem Parity
+
+### Added
+- **Ecosystem format interop** (#24): Claude Code plugins drop into `~/.oh/plugins/cache/` and auto-discover via `.claude-plugin/plugin.json`. Directory-packaged skills (`skill-name/SKILL.md` with companion docs). `.claude/skills/` and `.claude/agents/` discovered alongside `.oh/` equivalents. `.claude-plugin/marketplace.json` parser with source-typed entries (github/npm/url). Plugin-shipped `.mcp.json`, `hooks/hooks.json`, `.lsp.json` — discovered via helpers for runtime merge.
+- **CLAUDE.md + @-imports** (#25): Hierarchical loader walks `./.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`, `~/.claude/CLAUDE.md`. `@path` imports resolved inline with 5-hop cycle cap. Injected alongside `.oh/memory/` (additive).
+- **Read-only Bash auto-approve** (#25): Allowlist of pure inspection commands (ls, cat, grep, find, git status/log/diff, …) short-circuits the permission prompt. Rejects `sed -i`, `tee`, `git commit/push`, redirects.
+- **Settings `env:` injection** (#25): New `env: { KEY: VALUE }` field in `.oh/config.yaml` (mirrors CC's `settings.json.env`). Merged into child process environment via `safeEnv()` — every spawn site picks it up automatically.
+- **Skill frontmatter aliases** (#24): Anthropic kebab-case forms — `allowed-tools`, `disable-model-invocation`, `argument-hint`, `when-to-use` — accepted alongside the existing camelCase. New fields: `license` (SPDX), `paths` (glob scoping), `context: fork` + `agent: <type>`.
+- **Agent frontmatter additions** (#24): `model`, `disallowedTools`, `isolation`, `mcpServers`, `hooks`. Tools field accepts YAML array OR space/comma-separated string.
+- **`/plugin` command** (#24): Alias of `/plugins` with new `info <name>` subcommand showing the full manifest.
+- **License gate on `/skill-install`** (#24): Refuses non-permissive SPDX licenses unless `--accept-license=<id>` passed. `installable: false` registry entries are link-only (for viral licenses like CC-BY-SA).
+- **Registry expanded** (#24): 4 → 23 entries with `license` + `attribution` + `upstream` metadata. 7 OH-native MIT, 8 superpowers MIT, 6 CLI-Anything Apache-2.0, 2 Trail-of-Bits CC-BY-SA (link-only).
+- **7 bundled skills** (#24): code-review, commit, debug, tdd, diagnose, plan, simplify. Shipped in npm package, loaded with `[bundled]` source tag.
+- **`/skills` listing command** (#24): Lists all discoverable skills with source tags.
+
+### Changed
+- **Hook matcher** (#25): Accepts `/regex/flags` and `glob*` patterns alongside legacy substring match. Invalid regex fails closed.
+- **Compound-command permission parsing** (#25): Evaluates `cmd1 && cmd2`, `a | b`, `x; y` per-sub-command with most-restrictive-wins (deny > ask > allow). Process wrappers (`timeout`, `nice`, `nohup`, `stdbuf`) stripped before matching. Closes the `git log && rm -rf /` bypass class.
+- **AI review workflow** (#24): Converted from `pull_request` auto-trigger to `issue_comment`-mention trigger (`@openharness` or `/oh-review`). Shell-injection fix — PR content routed through env vars and delivered via stdin, never interpolated into a shell-quoted string. 15-min job ceiling + 10-min inner timeout.
+- **MonitorTool** (#24): Use `proc.on("close")` instead of `"exit"` to avoid draining race on fast-exiting commands — fixes the previously-flaky "filters output by pattern" test.
+
+### Fixed
+- **`SessionSearchTool` test isolation** (#26): Singleton DB now honors `OH_SESSION_DB_PATH` env var for test isolation. The "empty DB returns no results" test no longer fails on machines with real session history.
+
+### Summary
+976 tests (up from 890 — **+86 tests**; 40 in this release alone across skills, plugins, agents, marketplace, memory, hooks, permissions, safe-env, session-db). 42 tools, 79 commands. Full typecheck + lint clean. Two PRs merged (#24, #25) closing the "this feels like Claude Code" ecosystem surface gap. Remaining Tier A item (hook JSON I/O mode) deferred to next sprint.
+
 ## 2.8.0 (2026-04-16) — Full Test Coverage
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhijiewang/openharness",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Open-source terminal coding agent. Works with any LLM.",
   "type": "module",
   "bin": {

--- a/src/harness/session-db.ts
+++ b/src/harness/session-db.ts
@@ -205,12 +205,32 @@ export function rebuildIndex(db: Database.Database, sessionsDir?: string): numbe
 // ── Singleton Connection ──
 
 let _singletonDb: Database.Database | null = null;
+let _singletonDbPath: string | null = null;
 
-/** Get a shared DB connection (opens once, reuses thereafter) */
+/**
+ * Get a shared DB connection (opens once, reuses thereafter).
+ *
+ * Honors the `OH_SESSION_DB_PATH` environment variable for test isolation.
+ * When the env var changes between calls, the old singleton is closed and a
+ * new one is opened at the new path — this lets tests point at a tmp dir
+ * without leaking into the user's real `~/.oh/sessions.db`.
+ */
 export function getSessionDb(): Database.Database {
-  if (!_singletonDb) {
-    _singletonDb = openSessionDb();
+  const envPath = process.env.OH_SESSION_DB_PATH;
+  const targetPath = envPath || DEFAULT_DB_PATH;
+  if (_singletonDb && _singletonDbPath === targetPath) {
+    return _singletonDb;
   }
+  if (_singletonDb) {
+    try {
+      _singletonDb.close();
+    } catch {
+      /* ignore */
+    }
+    _singletonDb = null;
+  }
+  _singletonDb = openSessionDb(targetPath);
+  _singletonDbPath = targetPath;
   return _singletonDb;
 }
 

--- a/src/tools/tools-basic.test.ts
+++ b/src/tools/tools-basic.test.ts
@@ -617,10 +617,23 @@ describe("tools-basic", () => {
 
   it("SessionSearchTool — returns no results for empty DB", async () => {
     const { SessionSearchTool } = await import("./SessionSearchTool/index.js");
+    const { closeGlobalSessionDb } = await import("../harness/session-db.js");
+    // Point the singleton at a tmp DB so we don't pollute (or get polluted by)
+    // the user's real ~/.oh/sessions.db. Without this the test is non-deterministic
+    // based on what's in the developer / CI user's session history.
     const tmp = makeTmpDir();
-    const result = await SessionSearchTool.call({ query: "authentication" }, ctx(tmp));
-    assert.equal(result.isError, false);
-    assert.ok(result.output.includes("No matching sessions"));
+    const prevEnv = process.env.OH_SESSION_DB_PATH;
+    process.env.OH_SESSION_DB_PATH = join(tmp, "sessions.db");
+    closeGlobalSessionDb();
+    try {
+      const result = await SessionSearchTool.call({ query: "authentication" }, ctx(tmp));
+      assert.equal(result.isError, false);
+      assert.ok(result.output.includes("No matching sessions"));
+    } finally {
+      if (prevEnv !== undefined) process.env.OH_SESSION_DB_PATH = prevEnv;
+      else delete process.env.OH_SESSION_DB_PATH;
+      closeGlobalSessionDb();
+    }
   });
 
   it("SkillTool — path traversal blocked via ..", async () => {


### PR DESCRIPTION
## Summary

Ship the two feature PRs that merged today:
- #24 — Claude Code plugin/skill/agent format interop
- #25 — Claude Code parity sprint (6 of 7 Tier A items)

Plus a long-overdue fix to the `SessionSearchTool` test that's been red throughout the session.

## What's in this PR

1. **Version bump** 2.8.0 → 2.9.0 in `package.json`
2. **CHANGELOG.md entry** summarizing both feature PRs
3. **SessionSearchTool test isolation** (`src/harness/session-db.ts`, `src/tools/tools-basic.test.ts`) — `getSessionDb()` singleton now honors `OH_SESSION_DB_PATH` for test isolation; the test points it at a tmp path so it no longer fails on machines with real session history

## Stats

- 976/976 tests passing (first fully-green run this cycle)
- Typecheck + lint clean
- No breaking changes

## After merge

Tag `v2.9.0` on main:
```
git checkout main && git pull
git tag -a v2.9.0 -m "v2.9.0 — Claude Code ecosystem parity"
git push origin v2.9.0
```

The `.github/workflows/publish.yml` workflow triggers on `v*` tags and:
1. Runs full build + test suite
2. Publishes to npm with provenance (`npm publish --access public --provenance`)
3. Creates a GitHub Release

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm test` — 976/976 pass
- [ ] After merge + tag: publish workflow succeeds; `npm view @zhijiewang/openharness version` returns `2.9.0`