### PR TITLE
feat: Hook JSON I/O mode — Tier A #5 (final)

### DIFF
--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -21,8 +21,21 @@ export type HookDef = {
   command?: string; // shell command hook
   http?: string; // HTTP POST hook (URL)
   prompt?: string; // LLM prompt hook (yes/no question)
-  match?: string; // tool name pattern filter
+  match?: string; // tool name pattern filter — substring, /regex/flags, or glob*
   timeout?: number; // timeout in ms (default 10000)
+  /**
+   * When true (and this hook has a `command`), OH sends a JSON envelope
+   * `{event, ...context}` on stdin and parses a JSON response from stdout.
+   * Response shape (Claude Code compatible):
+   *   { "decision": "allow" | "deny",
+   *     "reason"?: string,
+   *     "hookSpecificOutput"?: {...} }
+   *
+   * When false (default), OH passes context via `OH_EVENT` / `OH_TOOL_NAME`
+   * env vars and gates on the command's exit code (0 = allow). The env-var
+   * mode remains the default for backward compatibility.
+   */
+  jsonIO?: boolean;
 };
 
 export type HooksConfig = {

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { describe, it } from "node:test";
-import { emitHook, emitHookAsync, matchesHook } from "./hooks.js";
+import { makeTmpDir } from "../test-helpers.js";
+import { invalidateConfigCache } from "./config.js";
+import { emitHook, emitHookAsync, invalidateHookCache, matchesHook } from "./hooks.js";
 
 describe("emitHook", () => {
   it("returns true when no hooks configured (default)", () => {
@@ -58,5 +61,135 @@ describe("matchesHook — matcher forms", () => {
   it("invalid regex fails closed (no match)", () => {
     // Unmatched bracket — constructor throws → matcher returns false
     assert.equal(matchesHook({ command: "x", match: "/[unclosed/" }, { toolName: "Anything" }), false);
+  });
+});
+
+// ── JSON I/O hook mode (Tier A #5) ──
+
+function withTmpCwd(fn: (dir: string) => void) {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    fn(dir);
+  } finally {
+    process.chdir(original);
+    invalidateHookCache();
+    invalidateConfigCache();
+  }
+}
+
+/** Write a minimal .oh/config.yaml with a single preToolUse hook. */
+function writeHookConfig(dir: string, hookDef: { command: string; jsonIO?: boolean; timeout?: number }) {
+  mkdirSync(`${dir}/.oh`, { recursive: true });
+  const json = JSON.stringify(hookDef.jsonIO ?? false);
+  const body = [
+    "provider: mock",
+    "model: mock",
+    "permissionMode: ask",
+    "hooks:",
+    "  preToolUse:",
+    `    - command: ${JSON.stringify(hookDef.command)}`,
+    `      jsonIO: ${json}`,
+    ...(hookDef.timeout ? [`      timeout: ${hookDef.timeout}`] : []),
+    "",
+  ].join("\n");
+  writeFileSync(`${dir}/.oh/config.yaml`, body);
+  invalidateConfigCache();
+  invalidateHookCache();
+}
+
+describe("hook JSON I/O mode", () => {
+  it("allows tool when hook responds with {decision: 'allow'}", () => {
+    withTmpCwd((dir) => {
+      // Node-based hook: read stdin, echo {decision:"allow"}
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data', c => d+=c); process.stdin.on('end', () => { JSON.parse(d); process.stdout.write(JSON.stringify({decision:'allow'})); });",
+      );
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      const result = emitHook("preToolUse", { toolName: "Bash" });
+      assert.equal(result, true);
+    });
+  });
+
+  it("blocks tool when hook responds with {decision: 'deny'}", () => {
+    withTmpCwd((dir) => {
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data', c => d+=c); process.stdin.on('end', () => { process.stdout.write(JSON.stringify({decision:'deny',reason:'blocked'})); });",
+      );
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      const result = emitHook("preToolUse", { toolName: "Bash" });
+      assert.equal(result, false);
+    });
+  });
+
+  it("hook receives JSON envelope on stdin containing event + context", () => {
+    withTmpCwd((dir) => {
+      // .cjs extension forces CommonJS so `require` is available.
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.json`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         let d = '';
+         process.stdin.on('data', c => d += c);
+         process.stdin.on('end', () => {
+           fs.writeFileSync('${outEsc}', d);
+           process.stdout.write(JSON.stringify({decision:'allow'}));
+         });`,
+      );
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      emitHook("preToolUse", { toolName: "Bash", toolArgs: "ls -la" });
+      const captured = JSON.parse(readFileSync(outPath, "utf-8"));
+      assert.equal(captured.event, "preToolUse");
+      assert.equal(captured.toolName, "Bash");
+      assert.equal(captured.toolArgs, "ls -la");
+    });
+  });
+
+  it("malformed JSON on stdout fails closed (deny)", () => {
+    withTmpCwd((dir) => {
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(scriptPath, "process.stdout.write('this is not JSON');");
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      const result = emitHook("preToolUse", { toolName: "Bash" });
+      assert.equal(result, false);
+    });
+  });
+
+  it("empty stdout with exit 0 allows (falls back to exit-code gating)", () => {
+    withTmpCwd((dir) => {
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(scriptPath, "process.exit(0);");
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      const result = emitHook("preToolUse", { toolName: "Bash" });
+      assert.equal(result, true);
+    });
+  });
+
+  it("non-zero exit blocks even with allow JSON in stdout", () => {
+    withTmpCwd((dir) => {
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(scriptPath, "process.stdout.write(JSON.stringify({decision:'allow'})); process.exit(1);");
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: true });
+      const result = emitHook("preToolUse", { toolName: "Bash" });
+      assert.equal(result, false);
+    });
+  });
+
+  it("env-var mode still works when jsonIO is false (back-compat)", () => {
+    withTmpCwd((dir) => {
+      // Classic env-var hook: reads $OH_TOOL_NAME, exits 0 for Read, 1 otherwise
+      const scriptPath = `${dir}/hook.mjs`;
+      writeFileSync(scriptPath, "process.exit(process.env.OH_TOOL_NAME === 'Read' ? 0 : 1);");
+      writeHookConfig(dir, { command: `node ${JSON.stringify(scriptPath)}`, jsonIO: false });
+      assert.equal(emitHook("preToolUse", { toolName: "Read" }), true);
+      assert.equal(emitHook("preToolUse", { toolName: "Bash" }), false);
+    });
   });
 });

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -174,6 +174,97 @@ function runCommandHookAsync(command: string, env: Record<string, string>, timeo
   });
 }
 
+/**
+ * Run a JSON-mode command hook (Claude Code convention).
+ *
+ * Sends `{event, ...context}` as JSON on stdin. Parses stdout as JSON
+ * `{ decision: "allow" | "deny", reason?: string, hookSpecificOutput?: any }`.
+ *
+ * Gating logic:
+ *   - `decision: "deny"` → blocks (returns false).
+ *   - `decision: "allow"` or omitted decision → allow (returns true).
+ *   - Non-zero exit code → block.
+ *   - Invalid/empty JSON on stdout → fall back to exit code (0 = allow).
+ *   - Timeout or spawn error → block.
+ */
+function runJsonIoHookAsync(
+  command: string,
+  env: Record<string, string>,
+  event: HookEvent,
+  ctx: HookContext,
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn(command, {
+      shell: true,
+      timeout: timeoutMs,
+      stdio: ["pipe", "pipe", "pipe"],
+      env,
+    });
+
+    let settled = false;
+    let stdoutBuf = "";
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill();
+        resolve(false);
+      }
+    }, timeoutMs);
+
+    proc.stdout?.on("data", (chunk) => {
+      stdoutBuf += chunk.toString();
+    });
+
+    // Write the event + context JSON envelope to stdin then close it so the
+    // hook knows there's no more input coming.
+    try {
+      const payload = JSON.stringify({ event, ...ctx });
+      proc.stdin?.end(payload);
+    } catch {
+      /* stdin already closed — ignore */
+    }
+
+    proc.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+
+      // Non-zero exit is always a block, regardless of stdout.
+      if ((code ?? 1) !== 0) {
+        resolve(false);
+        return;
+      }
+
+      // Empty stdout → treat exit code as the signal (allow for exit 0).
+      if (!stdoutBuf.trim()) {
+        resolve(true);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdoutBuf) as { decision?: string };
+        if (parsed.decision === "deny") {
+          resolve(false);
+        } else {
+          resolve(true); // "allow" or omitted → allow
+        }
+      } catch {
+        // Malformed JSON with a zero exit — fail closed conservatively.
+        resolve(false);
+      }
+    });
+
+    proc.on("error", () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve(false);
+      }
+    });
+  });
+}
+
 /** Run an HTTP hook. POSTs context as JSON, expects { allowed: true/false }. */
 async function runHttpHook(url: string, event: HookEvent, ctx: HookContext, timeoutMs = 10_000): Promise<boolean> {
   try {
@@ -212,6 +303,12 @@ async function executeHookDef(def: HookDef, event: HookEvent, ctx: HookContext):
 
   if (def.command) {
     const env = buildEnv(event, ctx);
+    // JSON-mode (Claude Code convention): send `{event, ...ctx}` on stdin,
+    // parse `{decision}` from stdout. Env-var mode (legacy default): gate on
+    // exit code.
+    if (def.jsonIO) {
+      return runJsonIoHookAsync(def.command, env, event, ctx, timeout);
+    }
     const code = await runCommandHookAsync(def.command, env, timeout);
     return code === 0;
   }
@@ -246,13 +343,28 @@ export function emitHook(event: HookEvent, ctx: HookContext = {}): boolean {
       if (!matchesHook(def, ctx)) continue;
 
       if (def.command) {
+        const input = def.jsonIO ? JSON.stringify({ event, ...ctx }) : undefined;
         const result = spawnSync(def.command, {
           shell: true,
           timeout: def.timeout ?? 10_000,
           stdio: "pipe",
           env,
+          input,
         });
         if (result.status !== 0 || result.error) return false;
+        // JSON mode: parse stdout for {decision: "deny"} → block. Allow on empty
+        // stdout (exit-code already gated above). Malformed JSON fails closed.
+        if (def.jsonIO) {
+          const out = result.stdout?.toString() ?? "";
+          if (out.trim()) {
+            try {
+              const parsed = JSON.parse(out) as { decision?: string };
+              if (parsed.decision === "deny") return false;
+            } catch {
+              return false;
+            }
+          }
+        }
       }
       // HTTP and prompt hooks for preToolUse are handled in emitHookAsync
     }


### PR DESCRIPTION
## Summary

Final Tier A item from the Claude Code parity roadmap. Hook configs can now opt into CC's structured-I/O convention via `jsonIO: true` — decisions carry reasons and structured output instead of just an exit code.

## Behavior

When a command hook has `jsonIO: true`:
- OH writes `{event, ...context}` as JSON to the hook's stdin and closes it
- OH parses stdout as JSON: `{decision?: "allow"|"deny", reason?, hookSpecificOutput?}`
- `decision: "deny"` → blocks
- `decision: "allow"` or omitted → allows
- Non-zero exit → blocks regardless of stdout
- Malformed JSON + zero exit → fails closed (blocks) — conservative default
- Empty stdout + zero exit → falls back to exit-code gating (allows)

Env-var mode (the existing behavior) remains the **default**. No migration required.

## Example

```yaml
hooks:
  preToolUse:
    - command: node scripts/pre-tool-gate.cjs
      jsonIO: true
      match: /^(Bash|Edit)$/
```

```js
// scripts/pre-tool-gate.cjs
let input = '';
process.stdin.on('data', c => input += c);
process.stdin.on('end', () => {
  const { event, toolName, toolArgs } = JSON.parse(input);
  const decision = toolArgs?.includes('rm -rf') ? 'deny' : 'allow';
  process.stdout.write(JSON.stringify({
    decision,
    reason: decision === 'deny' ? 'destructive command blocked by policy' : undefined,
  }));
});
```

## Stats

- 983/983 tests pass (+7 in this PR); typecheck + lint clean
- No breaking changes
- Completes the 7-item Tier A set that started with PR #25

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 983/983 pass
- [x] Write a CC-style JSON hook, verify `{decision:'deny'}` blocks and `{decision:'allow'}` allows
- [x] Confirm existing env-var hooks still work unchanged