### PR TITLE
feat: additional hook events (postToolUseFailure, userPromptSubmit, permissionRequest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Three new hook events mirroring Claude Code semantics:
+  - `postToolUseFailure` fires when a tool throws or returns `{isError: true}`. Mutually exclusive with `postToolUse` (success-only now).
+  - `userPromptSubmit` fires before the user's prompt reaches the LLM. Can block (decision: "deny") or prepend context (`hookSpecificOutput.additionalContext`).
+  - `permissionRequest` fires when a tool needs approval, between `preToolUse` and the interactive ask prompt. Can respond `{decision: "allow" | "deny" | "ask"}` to short-circuit or fall through.
+- `HookOutcome` type and `emitHookWithOutcome` function (exported from `src/harness/hooks.ts`) for structured decision + context return values.
+- `parseJsonIoResponse` helper (exported) for parsing hook jsonIO-mode stdout.
+- Env vars: `OH_PROMPT`, `OH_TOOL_ERROR`, `OH_ERROR_MESSAGE`, `OH_PERMISSION_ACTION`.
+- `docs/hooks.md` — reference for all 15 hook events.
+
+### Changed
+- `postToolUse` now fires only on successful tool execution (not on `isError: true`). Previously fired on both. This is a semantic change; tools that report errors now route to `postToolUseFailure` instead.
+
 ## 2.12.0 (2026-04-18) — OAuth 2.1 for Remote MCP
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ hooks:
 
 Use `match` to restrict a hook to a specific tool name (e.g., `match: Bash` only triggers for the Bash tool).
 
+See [docs/hooks.md](docs/hooks.md) for the full event reference including the new `userPromptSubmit`, `permissionRequest`, and `postToolUseFailure` events.
+
 ## Cybergotchi
 
 OpenHarness ships with a Tamagotchi-style companion that lives in the side panel. It reacts to your session in real time — celebrating streaks, complaining when tools fail, and getting hungry if you ignore it.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,168 @@
+# Hooks
+
+Hooks let you run arbitrary commands or HTTP callbacks at well-defined points in openHarness's execution. Configure them in `.oh/config.yaml` under the `hooks:` key.
+
+## Events
+
+| Event | Fires | Can block? | Notes |
+|---|---|---|---|
+| `sessionStart` | When a REPL session starts | No | |
+| `sessionEnd` | When a REPL session ends | No | |
+| `preToolUse` | Before any tool executes | **Yes** | Return `{decision: "deny"}` to block. |
+| `postToolUse` | After a tool executes successfully | No | Does NOT fire if the tool errored — see `postToolUseFailure`. |
+| `postToolUseFailure` | After a tool throws OR returns `isError: true` | No | Notify-only. Mutually exclusive with `postToolUse`. |
+| `userPromptSubmit` | Before the user's prompt reaches the LLM | **Yes** | Can also prepend context — see below. |
+| `permissionRequest` | When a tool permission check says "needs approval" | **Yes** | 3-state: `allow` / `deny` / `ask`. |
+| `fileChanged` | After a tool edits a file | No | |
+| `cwdChanged` | When `cd` changes the working directory | No | |
+| `subagentStart` | When an AgentTool invocation starts | No | |
+| `subagentStop` | When an AgentTool invocation ends | No | |
+| `preCompact` | Before conversation history is compacted | No | |
+| `postCompact` | After compaction completes | No | |
+| `configChange` | When `.oh/config.yaml` changes on disk | No | |
+| `notification` | Reserved for future use | No | |
+
+## Two hook modes
+
+### JSON I/O mode (`jsonIO: true`)
+
+The hook receives a JSON envelope on stdin and writes a JSON response on stdout. This is the preferred mode for blocking hooks and for hooks that want to prepend context.
+
+**Stdin (input):**
+```json
+{
+  "event": "userPromptSubmit",
+  "prompt": "the user's prompt text",
+  "sessionId": "...",
+  "model": "anthropic/claude-opus-4-7",
+  "provider": "anthropic",
+  "permissionMode": "ask"
+}
+```
+
+Fields vary by event — see the event reference below.
+
+**Stdout (response):**
+```json
+{
+  "decision": "allow" | "deny",
+  "reason": "optional string shown to the user on deny",
+  "hookSpecificOutput": {
+    "additionalContext": "string prepended to the prompt (userPromptSubmit only)",
+    "decision": "allow" | "deny" | "ask"
+  }
+}
+```
+
+All fields are optional. Unknown fields are ignored. Malformed JSON is treated as an empty response.
+
+### Env-mode (default)
+
+The hook is a shell command. Context fields are passed via `OH_*` environment variables. Exit code gates the decision:
+
+| Event | Exit 0 | Nonzero exit |
+|---|---|---|
+| `preToolUse` | allow | deny (tool blocked) |
+| `userPromptSubmit` | allow | deny (prompt blocked with generic message) |
+| `permissionRequest` | fall through to interactive ask | deny |
+| `postToolUseFailure` | (ignored — notify-only) | (ignored) |
+| all other events | (ignored — fire-and-forget) | (ignored) |
+
+Env vars set per event:
+- `OH_EVENT` — the event name
+- `OH_TOOL_NAME`, `OH_TOOL_ARGS`, `OH_TOOL_OUTPUT`, `OH_TOOL_INPUT_JSON` — for tool events
+- `OH_PROMPT` — for `userPromptSubmit` (capped at 8KB on all platforms)
+- `OH_TOOL_ERROR`, `OH_ERROR_MESSAGE` — for `postToolUseFailure`
+- `OH_PERMISSION_ACTION` — for `permissionRequest` (value: `ask`, `allow`, or `deny`)
+- `OH_SESSION_ID`, `OH_MODEL`, `OH_PROVIDER`, `OH_PERMISSION_MODE`
+
+## Examples
+
+### Fail-log on every tool failure
+
+```yaml
+hooks:
+  postToolUseFailure:
+    - command: >-
+        sh -c 'echo "[$(date)] $OH_TOOL_NAME failed: $OH_ERROR_MESSAGE" >> /tmp/oh-fails.log'
+```
+
+### Prepend a standing instruction to every user prompt
+
+```yaml
+hooks:
+  userPromptSubmit:
+    - command: node ./prepend-context.cjs
+      jsonIO: true
+```
+
+`./prepend-context.cjs`:
+```js
+let d = "";
+process.stdin.on("data", (c) => (d += c));
+process.stdin.on("end", () => {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      additionalContext: "[system: always respond in under 200 words unless asked otherwise]",
+    },
+  }));
+});
+```
+
+### Deny Bash in "ask" mode without prompting
+
+```yaml
+hooks:
+  permissionRequest:
+    - command: node ./gate-bash.cjs
+      jsonIO: true
+      match: "Bash"
+```
+
+`./gate-bash.cjs`:
+```js
+let d = "";
+process.stdin.on("data", (c) => (d += c));
+process.stdin.on("end", () => {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { decision: "deny", reason: "Bash is disabled by policy" },
+  }));
+});
+```
+
+## Multi-hook merge
+
+You can configure multiple hooks per event. They run in order. Merge rules:
+- First `deny` (in `decision` or `hookSpecificOutput.decision`) short-circuits — remaining hooks do NOT run.
+- First `hookSpecificOutput.decision: "allow"` short-circuits — remaining hooks do NOT run.
+- Multiple `hookSpecificOutput.additionalContext` values concatenate in hook-list order, separated by `\n\n`.
+- If any hook returns `"ask"` and none deny or allow, the final `permissionDecision` is `"ask"` (fall through).
+
+## Pattern matching with `match`
+
+Filter a hook by tool name: substring, glob-style, or regex:
+
+```yaml
+hooks:
+  preToolUse:
+    - command: ./log.sh
+      match: "Bash"           # substring
+    - command: ./watch.sh
+      match: "File*"          # glob
+    - command: ./mcp-audit.sh
+      match: "/mcp__.*/"      # regex
+```
+
+## Claude Code compatibility
+
+openHarness mirrors Claude Code's hook semantics where possible. Notable differences:
+- openHarness uses **camelCase** context field names (`toolName`, `toolInput`); Claude Code uses **snake_case** (`tool_name`, `tool_input`). Snake_case aliases are not yet supported.
+- openHarness does not yet support prompt *rewriting* via `userPromptSubmit` — only prepending via `additionalContext`.
+
+## Timeouts and gotchas
+
+- Default hook timeout: **10 seconds**. Override per-hook with `timeout: <ms>`.
+- `userPromptSubmit` runs between keypress and LLM dispatch — keep it fast.
+- `OH_PROMPT` is truncated to 8KB to fit within Windows env-var length limits.
+- `permissionRequest` fires ONLY in the `needs-approval && askUser` branch. If the tool is pre-approved (permissionMode: trust, or matching allow rule) OR pre-denied, the hook does not fire.
+- Biome / lint / format: openHarness's pre-commit hook runs `biome check` — ensure your hook scripts don't trip it if they live in the repo.

--- a/src/harness/config.ts
+++ b/src/harness/config.ts
@@ -63,6 +63,9 @@ export type HooksConfig = {
   sessionEnd?: HookDef[];
   preToolUse?: HookDef[];
   postToolUse?: HookDef[];
+  postToolUseFailure?: HookDef[];
+  userPromptSubmit?: HookDef[];
+  permissionRequest?: HookDef[];
   fileChanged?: HookDef[];
   cwdChanged?: HookDef[];
   subagentStart?: HookDef[];

--- a/src/harness/hooks-env.test.ts
+++ b/src/harness/hooks-env.test.ts
@@ -3,45 +3,172 @@
  */
 
 import assert from "node:assert/strict";
-import test from "node:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { makeTmpDir } from "../test-helpers.js";
+import { invalidateConfigCache } from "./config.js";
 import type { HookContext } from "./hooks.js";
+import { emitHookAsync, invalidateHookCache } from "./hooks.js";
 
 // Test the buildEnv function indirectly by importing and calling emitHook
 // We can't test shell execution easily, but we CAN test the env var construction
 // by examining the HookContext type coverage
 
-test("HookContext supports all new env var fields", () => {
-  // Verify the type accepts all expected fields
-  const ctx: HookContext = {
-    toolName: "Bash",
-    toolArgs: '{"command":"echo hi"}',
-    toolOutput: "hi",
-    toolInputJson: '{"command":"echo hi"}',
-    sessionId: "test-123",
-    model: "gpt-4o",
-    provider: "openai",
-    permissionMode: "ask",
-    cost: "$0.0042",
-    tokens: "1000↑ 500↓",
-  };
+describe("HookContext type coverage", () => {
+  it("HookContext supports all new env var fields", () => {
+    // Verify the type accepts all expected fields
+    const ctx: HookContext = {
+      toolName: "Bash",
+      toolArgs: '{"command":"echo hi"}',
+      toolOutput: "hi",
+      toolInputJson: '{"command":"echo hi"}',
+      sessionId: "test-123",
+      model: "gpt-4o",
+      provider: "openai",
+      permissionMode: "ask",
+      cost: "$0.0042",
+      tokens: "1000↑ 500↓",
+    };
 
-  // All fields should be defined
-  assert.equal(ctx.toolName, "Bash");
-  assert.equal(ctx.sessionId, "test-123");
-  assert.equal(ctx.model, "gpt-4o");
-  assert.equal(ctx.provider, "openai");
-  assert.equal(ctx.permissionMode, "ask");
-  assert.equal(ctx.cost, "$0.0042");
-  assert.equal(ctx.tokens, "1000↑ 500↓");
-  assert.equal(ctx.toolInputJson, '{"command":"echo hi"}');
+    // All fields should be defined
+    assert.equal(ctx.toolName, "Bash");
+    assert.equal(ctx.sessionId, "test-123");
+    assert.equal(ctx.model, "gpt-4o");
+    assert.equal(ctx.provider, "openai");
+    assert.equal(ctx.permissionMode, "ask");
+    assert.equal(ctx.cost, "$0.0042");
+    assert.equal(ctx.tokens, "1000↑ 500↓");
+    assert.equal(ctx.toolInputJson, '{"command":"echo hi"}');
+  });
+
+  it("HookContext allows partial fields (all optional)", () => {
+    const minimal: HookContext = {};
+    assert.equal(minimal.toolName, undefined);
+    assert.equal(minimal.sessionId, undefined);
+
+    const withTool: HookContext = { toolName: "Read" };
+    assert.equal(withTool.toolName, "Read");
+    assert.equal(withTool.model, undefined);
+  });
 });
 
-test("HookContext allows partial fields (all optional)", () => {
-  const minimal: HookContext = {};
-  assert.equal(minimal.toolName, undefined);
-  assert.equal(minimal.sessionId, undefined);
+// ── Task 3: buildEnv env var mappings ──
 
-  const withTool: HookContext = { toolName: "Read" };
-  assert.equal(withTool.toolName, "Read");
-  assert.equal(withTool.model, undefined);
+function withTmpCwdAsync(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  return fn(dir).finally(() => {
+    process.chdir(original);
+    invalidateHookCache();
+    invalidateConfigCache();
+  });
+}
+
+/** Write a minimal .oh/config.yaml with a hook for the specified event. */
+function writeHookConfig(dir: string, event: string, scriptPath: string) {
+  mkdirSync(`${dir}/.oh`, { recursive: true });
+  const body = [
+    "provider: mock",
+    "model: mock",
+    "permissionMode: ask",
+    "hooks:",
+    `  ${event}:`,
+    `    - command: "node ${JSON.stringify(scriptPath).slice(1, -1)}"`,
+    "      jsonIO: false",
+    "",
+  ].join("\n");
+  writeFileSync(`${dir}/.oh/config.yaml`, body);
+  invalidateConfigCache();
+  invalidateHookCache();
+}
+
+describe("buildEnv — new event fields (Task 3)", () => {
+  it("OH_PROMPT carries userPromptSubmit prompt", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.txt`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         fs.writeFileSync('${outEsc}', process.env.OH_PROMPT ?? '');`,
+      );
+      writeHookConfig(dir, "userPromptSubmit", scriptPath);
+      await emitHookAsync("userPromptSubmit", { prompt: "hello world" });
+      const captured = readFileSync(outPath, "utf-8");
+      assert.equal(captured, "hello world");
+    });
+  });
+
+  it("OH_TOOL_ERROR carries postToolUseFailure toolError", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.txt`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         fs.writeFileSync('${outEsc}', process.env.OH_TOOL_ERROR ?? '');`,
+      );
+      writeHookConfig(dir, "postToolUseFailure", scriptPath);
+      await emitHookAsync("postToolUseFailure", { toolName: "Bash", toolError: "TimeoutError" });
+      const captured = readFileSync(outPath, "utf-8");
+      assert.equal(captured, "TimeoutError");
+    });
+  });
+
+  it("OH_ERROR_MESSAGE carries postToolUseFailure errorMessage", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.txt`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         fs.writeFileSync('${outEsc}', process.env.OH_ERROR_MESSAGE ?? '');`,
+      );
+      writeHookConfig(dir, "postToolUseFailure", scriptPath);
+      await emitHookAsync("postToolUseFailure", { toolName: "Bash", errorMessage: "command failed with exit 1" });
+      const captured = readFileSync(outPath, "utf-8");
+      assert.equal(captured, "command failed with exit 1");
+    });
+  });
+
+  it("OH_PERMISSION_ACTION carries permissionRequest permissionAction", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.txt`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         fs.writeFileSync('${outEsc}', process.env.OH_PERMISSION_ACTION ?? '');`,
+      );
+      writeHookConfig(dir, "permissionRequest", scriptPath);
+      await emitHookAsync("permissionRequest", { toolName: "Bash", permissionAction: "ask" });
+      const captured = readFileSync(outPath, "utf-8");
+      assert.equal(captured, "ask");
+    });
+  });
+
+  it("OH_PROMPT is truncated to 8KB", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      const outPath = `${dir}/captured.txt`;
+      const outEsc = outPath.replace(/\\/g, "/");
+      writeFileSync(
+        scriptPath,
+        `const fs = require('node:fs');
+         fs.writeFileSync('${outEsc}', process.env.OH_PROMPT ?? '');`,
+      );
+      writeHookConfig(dir, "userPromptSubmit", scriptPath);
+      const longPrompt = "x".repeat(10_000);
+      await emitHookAsync("userPromptSubmit", { prompt: longPrompt });
+      const captured = readFileSync(outPath, "utf-8");
+      // 8KB = 8192 chars
+      assert.equal(captured.length, 8192);
+      assert.equal(captured, "x".repeat(8192));
+    });
+  });
 });

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -250,3 +250,21 @@ describe("prompt hooks (LLM-decision)", () => {
     assert.equal(noHooks, true, "with no hooks configured, emitHookAsync should allow");
   });
 });
+
+describe("new hook event types (Task 1)", () => {
+  it("HookEvent accepts postToolUseFailure / userPromptSubmit / permissionRequest at type level", () => {
+    // Compile-time check only — if this file type-checks, the union accepts the new variants.
+    const events: Array<"postToolUseFailure" | "userPromptSubmit" | "permissionRequest"> = [
+      "postToolUseFailure",
+      "userPromptSubmit",
+      "permissionRequest",
+    ];
+    assert.equal(events.length, 3);
+  });
+
+  it("emitHook accepts the three new events without throwing (no hooks configured)", () => {
+    assert.equal(emitHook("postToolUseFailure", { toolName: "t", errorMessage: "x" }), true);
+    assert.equal(emitHook("userPromptSubmit", { prompt: "hi" }), true);
+    assert.equal(emitHook("permissionRequest", { toolName: "Bash", permissionAction: "ask" }), true);
+  });
+});

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { makeTmpDir } from "../test-helpers.js";
 import { invalidateConfigCache } from "./config.js";
@@ -539,5 +539,120 @@ describe("emitHookWithOutcome — env-mode exit-code mapping (Task 7)", () => {
   it("postToolUseFailure env-mode exit nonzero → still allowed (notify-only)", async () => {
     const o = await runEnvExitTest({ event: "postToolUseFailure", exitCode: 1 });
     assert.equal(o.allowed, true);
+  });
+});
+
+describe("emitHookWithOutcome — multi-hook merge semantics", () => {
+  it("two userPromptSubmit hooks: additionalContext concatenates in order, \\n\\n separated", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const s1 = `${dir}/h1.cjs`;
+      const s2 = `${dir}/h2.cjs`;
+      writeFileSync(
+        s1,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:'FIRST'}})); });",
+      );
+      writeFileSync(
+        s2,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:'SECOND'}})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  userPromptSubmit:",
+          `    - command: "node ${s1.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          `    - command: "node ${s2.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("userPromptSubmit", { prompt: "hi" });
+      assert.equal(outcome.allowed, true);
+      assert.equal(outcome.additionalContext, "FIRST\n\nSECOND");
+    });
+  });
+
+  it("first deny short-circuits — second hook does not run", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const s1 = `${dir}/h1.cjs`;
+      const s2 = `${dir}/h2.cjs`;
+      const marker = `${dir}/second-ran.marker`;
+      writeFileSync(
+        s1,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({decision:'deny',reason:'first said no'})); });",
+      );
+      writeFileSync(
+        s2,
+        `require("node:fs").writeFileSync(${JSON.stringify(marker).replace(/\\/g, "/")}, "ran"); let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write('{}'); });`,
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  userPromptSubmit:",
+          `    - command: "node ${s1.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          `    - command: "node ${s2.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("userPromptSubmit", { prompt: "hi" });
+      assert.equal(outcome.allowed, false);
+      assert.match(outcome.reason ?? "", /first said no/i);
+      assert.equal(existsSync(marker), false, "second hook should not have run");
+    });
+  });
+
+  it("permissionRequest: 'allow' short-circuits — second 'deny' hook does not override", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const s1 = `${dir}/h1.cjs`;
+      const s2 = `${dir}/h2.cjs`;
+      writeFileSync(
+        s1,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{decision:'allow'}})); });",
+      );
+      writeFileSync(
+        s2,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{decision:'deny'}})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  permissionRequest:",
+          `    - command: "node ${s1.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          `    - command: "node ${s2.replace(/\\/g, "/")}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("permissionRequest", { toolName: "Bash" });
+      assert.equal(outcome.allowed, true);
+      assert.equal(outcome.permissionDecision, "allow");
+    });
   });
 });

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -3,7 +3,14 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { makeTmpDir } from "../test-helpers.js";
 import { invalidateConfigCache } from "./config.js";
-import { emitHook, emitHookAsync, invalidateHookCache, matchesHook } from "./hooks.js";
+import {
+  emitHook,
+  emitHookAsync,
+  emitHookWithOutcome,
+  invalidateHookCache,
+  matchesHook,
+  parseJsonIoResponse,
+} from "./hooks.js";
 
 describe("emitHook", () => {
   it("returns true when no hooks configured (default)", () => {
@@ -266,5 +273,206 @@ describe("new hook event types (Task 1)", () => {
     assert.equal(emitHook("postToolUseFailure", { toolName: "t", errorMessage: "x" }), true);
     assert.equal(emitHook("userPromptSubmit", { prompt: "hi" }), true);
     assert.equal(emitHook("permissionRequest", { toolName: "Bash", permissionAction: "ask" }), true);
+  });
+});
+
+// ── Task 2: parseJsonIoResponse + emitHookWithOutcome ──
+
+describe("parseJsonIoResponse", () => {
+  it("parses allow decision without hookSpecificOutput", () => {
+    const r = parseJsonIoResponse(JSON.stringify({ decision: "allow" }));
+    assert.equal(r.decision, "allow");
+    assert.equal(r.additionalContext, undefined);
+    assert.equal(r.permissionDecision, undefined);
+  });
+
+  it("parses deny decision with reason", () => {
+    const r = parseJsonIoResponse(JSON.stringify({ decision: "deny", reason: "blocked" }));
+    assert.equal(r.decision, "deny");
+    assert.equal(r.reason, "blocked");
+  });
+
+  it("extracts hookSpecificOutput.additionalContext", () => {
+    const r = parseJsonIoResponse(
+      JSON.stringify({ decision: "allow", hookSpecificOutput: { additionalContext: "[hello]" } }),
+    );
+    assert.equal(r.additionalContext, "[hello]");
+  });
+
+  it("extracts hookSpecificOutput.decision as permissionDecision", () => {
+    const r = parseJsonIoResponse(JSON.stringify({ hookSpecificOutput: { decision: "deny", reason: "not allowed" } }));
+    assert.equal(r.permissionDecision, "deny");
+    assert.equal(r.reason, "not allowed");
+  });
+
+  it("returns empty object on malformed JSON (no throw)", () => {
+    const r = parseJsonIoResponse("{not valid");
+    assert.deepEqual(r, {});
+  });
+
+  it("returns empty object on non-object JSON", () => {
+    const r = parseJsonIoResponse(JSON.stringify("just a string"));
+    assert.deepEqual(r, {});
+  });
+
+  it("ignores unknown decision values", () => {
+    const r = parseJsonIoResponse(JSON.stringify({ decision: "maybe" }));
+    assert.equal(r.decision, undefined);
+  });
+
+  it("ignores unknown hookSpecificOutput.decision values", () => {
+    const r = parseJsonIoResponse(JSON.stringify({ hookSpecificOutput: { decision: "sometimes" } }));
+    assert.equal(r.permissionDecision, undefined);
+  });
+});
+
+describe("emitHookWithOutcome (no hooks configured)", () => {
+  it("returns {allowed: true} for every event with no config", async () => {
+    const events: Array<"postToolUseFailure" | "userPromptSubmit" | "permissionRequest"> = [
+      "postToolUseFailure",
+      "userPromptSubmit",
+      "permissionRequest",
+    ];
+    for (const e of events) {
+      const o = await emitHookWithOutcome(e, {});
+      assert.equal(o.allowed, true);
+      assert.equal(o.additionalContext, undefined);
+      assert.equal(o.permissionDecision, undefined);
+    }
+  });
+});
+
+// ── Async withTmpCwd for emitHookWithOutcome integration tests ──
+
+function withTmpCwdAsync(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  return fn(dir).finally(() => {
+    process.chdir(original);
+    invalidateHookCache();
+    invalidateConfigCache();
+  });
+}
+
+describe("emitHookWithOutcome (jsonIO hooks)", () => {
+  it("prepends additionalContext from a userPromptSubmit hook", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:'[PREFIX]'}})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  userPromptSubmit:",
+          `    - command: "node ${JSON.stringify(scriptPath).slice(1, -1)}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("userPromptSubmit", { prompt: "hi" });
+      assert.equal(outcome.allowed, true);
+      assert.equal(outcome.additionalContext, "[PREFIX]");
+    });
+  });
+
+  it("blocks on deny decision with reason", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({decision:'deny',reason:'nope'})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  userPromptSubmit:",
+          `    - command: "node ${JSON.stringify(scriptPath).slice(1, -1)}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("userPromptSubmit", { prompt: "hi" });
+      assert.equal(outcome.allowed, false);
+      assert.equal(outcome.reason, "nope");
+    });
+  });
+
+  it("returns permissionDecision from hookSpecificOutput for permissionRequest", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{decision:'allow'}})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  permissionRequest:",
+          `    - command: "node ${JSON.stringify(scriptPath).slice(1, -1)}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("permissionRequest", { toolName: "Bash" });
+      assert.equal(outcome.allowed, true);
+      assert.equal(outcome.permissionDecision, "allow");
+    });
+  });
+
+  it("treats postToolUseFailure as notify-only (ignores decision from hook)", async () => {
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      writeFileSync(
+        scriptPath,
+        "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({decision:'deny',reason:'nope'})); });",
+      );
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          "  postToolUseFailure:",
+          `    - command: "node ${JSON.stringify(scriptPath).slice(1, -1)}"`,
+          "      jsonIO: true",
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      const outcome = await emitHookWithOutcome("postToolUseFailure", { toolName: "Bash", errorMessage: "oops" });
+      // deny is ignored — notify-only
+      assert.equal(outcome.allowed, true);
+    });
   });
 });

--- a/src/harness/hooks.test.ts
+++ b/src/harness/hooks.test.ts
@@ -7,6 +7,7 @@ import {
   emitHook,
   emitHookAsync,
   emitHookWithOutcome,
+  type HookOutcome,
   invalidateHookCache,
   matchesHook,
   parseJsonIoResponse,
@@ -474,5 +475,69 @@ describe("emitHookWithOutcome (jsonIO hooks)", () => {
       // deny is ignored — notify-only
       assert.equal(outcome.allowed, true);
     });
+  });
+});
+
+describe("emitHookWithOutcome — env-mode exit-code mapping (Task 7)", () => {
+  async function runEnvExitTest(opts: {
+    event: "userPromptSubmit" | "permissionRequest" | "postToolUseFailure";
+    exitCode: number;
+  }): Promise<HookOutcome> {
+    let outcome!: HookOutcome;
+    await withTmpCwdAsync(async (dir) => {
+      const scriptPath = `${dir}/hook.cjs`;
+      writeFileSync(scriptPath, `process.exit(${opts.exitCode});`);
+      mkdirSync(`${dir}/.oh`, { recursive: true });
+      writeFileSync(
+        `${dir}/.oh/config.yaml`,
+        [
+          "provider: mock",
+          "model: mock",
+          "permissionMode: ask",
+          "hooks:",
+          `  ${opts.event}:`,
+          `    - command: "node ${scriptPath.replace(/\\/g, "/")}"`,
+          // NOTE: no jsonIO flag — this exercises the env-mode path
+          "",
+        ].join("\n"),
+      );
+      invalidateConfigCache();
+      invalidateHookCache();
+      outcome = await emitHookWithOutcome(opts.event, {});
+    });
+    return outcome;
+  }
+
+  it("userPromptSubmit env-mode exit 0 → allowed", async () => {
+    const o = await runEnvExitTest({ event: "userPromptSubmit", exitCode: 0 });
+    assert.equal(o.allowed, true);
+    assert.equal(o.additionalContext, undefined);
+  });
+
+  it("userPromptSubmit env-mode exit nonzero → denied", async () => {
+    const o = await runEnvExitTest({ event: "userPromptSubmit", exitCode: 1 });
+    assert.equal(o.allowed, false);
+  });
+
+  it("permissionRequest env-mode exit 0 → permissionDecision 'ask' (fall-through)", async () => {
+    const o = await runEnvExitTest({ event: "permissionRequest", exitCode: 0 });
+    assert.equal(o.allowed, true);
+    assert.equal(o.permissionDecision, "ask");
+  });
+
+  it("permissionRequest env-mode exit nonzero → permissionDecision 'deny'", async () => {
+    const o = await runEnvExitTest({ event: "permissionRequest", exitCode: 1 });
+    assert.equal(o.allowed, false);
+    assert.equal(o.permissionDecision, "deny");
+  });
+
+  it("postToolUseFailure env-mode exit 0 → allowed (notify-only)", async () => {
+    const o = await runEnvExitTest({ event: "postToolUseFailure", exitCode: 0 });
+    assert.equal(o.allowed, true);
+  });
+
+  it("postToolUseFailure env-mode exit nonzero → still allowed (notify-only)", async () => {
+    const o = await runEnvExitTest({ event: "postToolUseFailure", exitCode: 1 });
+    assert.equal(o.allowed, true);
   });
 });

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -93,6 +93,14 @@ function buildEnv(event: HookEvent, ctx: HookContext): Record<string, string> {
   if (ctx.newCwd) env.OH_NEW_CWD = ctx.newCwd;
   if (ctx.agentId) env.OH_AGENT_ID = ctx.agentId;
   if (ctx.message) env.OH_MESSAGE = ctx.message;
+  if (ctx.prompt !== undefined) {
+    // Cap at 8KB to avoid Windows env-var length limits.
+    const PROMPT_MAX = 8 * 1024;
+    env.OH_PROMPT = ctx.prompt.length > PROMPT_MAX ? ctx.prompt.slice(0, PROMPT_MAX) : ctx.prompt;
+  }
+  if (ctx.toolError !== undefined) env.OH_TOOL_ERROR = ctx.toolError;
+  if (ctx.errorMessage !== undefined) env.OH_ERROR_MESSAGE = ctx.errorMessage;
+  if (ctx.permissionAction !== undefined) env.OH_PERMISSION_ACTION = ctx.permissionAction;
   return env;
 }
 

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -19,6 +19,9 @@ export type HookEvent =
   | "sessionEnd"
   | "preToolUse"
   | "postToolUse"
+  | "postToolUseFailure"
+  | "userPromptSubmit"
+  | "permissionRequest"
   | "fileChanged"
   | "cwdChanged"
   | "subagentStart"
@@ -47,6 +50,14 @@ export type HookContext = {
   agentId?: string;
   /** For notification: the message */
   message?: string;
+  /** For userPromptSubmit: the raw prompt text the user is about to submit */
+  prompt?: string;
+  /** For postToolUseFailure: short error label ("TimeoutError", "ExecutionError", "ReportedError") */
+  toolError?: string;
+  /** For postToolUseFailure: full error message */
+  errorMessage?: string;
+  /** For permissionRequest: the decision OH would take absent the hook ("ask", "allow", "deny") — informational */
+  permissionAction?: "ask" | "allow" | "deny";
 };
 
 let cachedHooks: HooksConfig | null | undefined;

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -532,6 +532,29 @@ export type HookOutcome = {
 const NOTIFY_ONLY_OUTCOME_EVENTS: ReadonlySet<HookEvent> = new Set<HookEvent>(["postToolUseFailure"]);
 
 /**
+ * Map a command-hook's boolean (exit 0 / nonzero) result to a ParsedJsonIoResponse
+ * for the given event, applying per-event semantics:
+ *
+ * - userPromptSubmit: exit 0 → allow ({}); nonzero → deny.
+ * - permissionRequest: exit 0 → "ask" (fall through to user); nonzero → deny.
+ * - postToolUseFailure: notify-only — exit code is irrelevant, always return {}.
+ * - All other events: same as userPromptSubmit (exit 0 allow, nonzero deny).
+ */
+function mapEnvExitToOutcome(event: HookEvent, allowed: boolean): ParsedJsonIoResponse {
+  switch (event) {
+    case "permissionRequest":
+      return allowed
+        ? { permissionDecision: "ask" }
+        : { permissionDecision: "deny", decision: "deny", reason: "hook denied (exit code)" };
+    case "postToolUseFailure":
+      // notify-only; exit code is irrelevant
+      return {};
+    default:
+      return allowed ? {} : { decision: "deny", reason: "hook denied (exit code)" };
+  }
+}
+
+/**
  * Execute a single hook definition and return a ParsedJsonIoResponse for outcome merging.
  * Private to this module — not exported.
  */
@@ -553,15 +576,15 @@ async function runHookForOutcome(def: HookDef, event: HookEvent, ctx: HookContex
   }
 
   if (def.command) {
-    // env-var mode — gate on exit code
+    // env-var mode — apply per-event exit-code semantics
     const env = buildEnv(event, ctx);
     const code = await runCommandHookAsync(def.command, env, def.timeout ?? 10_000);
-    return code === 0 ? {} : { decision: "deny", reason: "hook denied (non-zero exit)" };
+    return mapEnvExitToOutcome(event, code === 0);
   }
 
   if (def.http) {
     const allowed = await runHttpHook(def.http, event, ctx, def.timeout ?? 10_000);
-    return allowed ? {} : { decision: "deny", reason: "http hook denied" };
+    return mapEnvExitToOutcome(event, allowed);
   }
 
   if (def.prompt) {

--- a/src/harness/hooks.ts
+++ b/src/harness/hooks.ts
@@ -186,26 +186,21 @@ function runCommandHookAsync(command: string, env: Record<string, string>, timeo
 }
 
 /**
- * Run a JSON-mode command hook (Claude Code convention).
+ * Run a JSON-mode command hook and return the raw stdout string.
  *
- * Sends `{event, ...context}` as JSON on stdin. Parses stdout as JSON
- * `{ decision: "allow" | "deny", reason?: string, hookSpecificOutput?: any }`.
- *
- * Gating logic:
- *   - `decision: "deny"` → blocks (returns false).
- *   - `decision: "allow"` or omitted decision → allow (returns true).
- *   - Non-zero exit code → block.
- *   - Invalid/empty JSON on stdout → fall back to exit code (0 = allow).
- *   - Timeout or spawn error → block.
+ * Rejects (throws) on timeout or spawn error so callers can decide how to
+ * interpret the failure. Returns an empty string when stdout is empty.
+ * Rejects when the process exits with a non-zero code (callers treat this as
+ * a block).
  */
-function runJsonIoHookAsync(
+function runJsonIoHookCaptureStdout(
   command: string,
   env: Record<string, string>,
   event: HookEvent,
   ctx: HookContext,
   timeoutMs = 10_000,
-): Promise<boolean> {
-  return new Promise((resolve) => {
+): Promise<string> {
+  return new Promise((resolve, reject) => {
     const proc = spawn(command, {
       shell: true,
       timeout: timeoutMs,
@@ -219,7 +214,7 @@ function runJsonIoHookAsync(
       if (!settled) {
         settled = true;
         proc.kill();
-        resolve(false);
+        reject(new Error("hook timed out"));
       }
     }, timeoutMs);
 
@@ -241,39 +236,64 @@ function runJsonIoHookAsync(
       settled = true;
       clearTimeout(timer);
 
-      // Non-zero exit is always a block, regardless of stdout.
       if ((code ?? 1) !== 0) {
-        resolve(false);
+        reject(new Error(`hook exited with code ${code ?? 1}`));
         return;
       }
 
-      // Empty stdout → treat exit code as the signal (allow for exit 0).
-      if (!stdoutBuf.trim()) {
-        resolve(true);
-        return;
-      }
-
-      try {
-        const parsed = JSON.parse(stdoutBuf) as { decision?: string };
-        if (parsed.decision === "deny") {
-          resolve(false);
-        } else {
-          resolve(true); // "allow" or omitted → allow
-        }
-      } catch {
-        // Malformed JSON with a zero exit — fail closed conservatively.
-        resolve(false);
-      }
+      resolve(stdoutBuf);
     });
 
-    proc.on("error", () => {
+    proc.on("error", (err) => {
       if (!settled) {
         settled = true;
         clearTimeout(timer);
-        resolve(false);
+        reject(err);
       }
     });
   });
+}
+
+/**
+ * Run a JSON-mode command hook (Claude Code convention).
+ *
+ * Sends `{event, ...context}` as JSON on stdin. Parses stdout as JSON
+ * `{ decision: "allow" | "deny", reason?: string, hookSpecificOutput?: any }`.
+ *
+ * Gating logic:
+ *   - `decision: "deny"` → blocks (returns false).
+ *   - `decision: "allow"` or omitted decision → allow (returns true).
+ *   - Non-zero exit code → block.
+ *   - Invalid/empty JSON on stdout → fall back to exit code (0 = allow).
+ *   - Timeout or spawn error → block.
+ */
+async function runJsonIoHookAsync(
+  command: string,
+  env: Record<string, string>,
+  event: HookEvent,
+  ctx: HookContext,
+  timeoutMs = 10_000,
+): Promise<boolean> {
+  let stdout: string;
+  try {
+    stdout = await runJsonIoHookCaptureStdout(command, env, event, ctx, timeoutMs);
+  } catch {
+    // timeout, spawn error, or non-zero exit — block
+    return false;
+  }
+
+  // Empty stdout → treat exit code as the signal (allow for exit 0).
+  if (!stdout.trim()) {
+    return true;
+  }
+
+  try {
+    const parsed = JSON.parse(stdout) as { decision?: string };
+    return parsed.decision !== "deny";
+  } catch {
+    // Malformed JSON with a zero exit — fail closed conservatively.
+    return false;
+  }
 }
 
 /** Run an HTTP hook. POSTs context as JSON, expects { allowed: true/false }. */
@@ -456,4 +476,144 @@ export async function emitHookAsync(event: HookEvent, ctx: HookContext = {}): Pr
     if (event === "preToolUse" && !allowed) return false;
   }
   return true;
+}
+
+// ── Structured-outcome hook emitter (Task 2) ──
+
+/** Parsed shape of a jsonIO hook's stdout JSON response. */
+export type ParsedJsonIoResponse = {
+  decision?: "allow" | "deny";
+  reason?: string;
+  additionalContext?: string;
+  permissionDecision?: "allow" | "deny" | "ask";
+};
+
+/** Parse a hook's stdout as a jsonIO envelope. Returns an empty object on malformed input. */
+export function parseJsonIoResponse(raw: string): ParsedJsonIoResponse {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return {};
+  const rec = obj as Record<string, unknown>;
+  const out: ParsedJsonIoResponse = {};
+  if (rec.decision === "allow" || rec.decision === "deny") out.decision = rec.decision;
+  if (typeof rec.reason === "string") out.reason = rec.reason;
+  const hso = rec.hookSpecificOutput;
+  if (hso && typeof hso === "object" && !Array.isArray(hso)) {
+    const hsoRec = hso as Record<string, unknown>;
+    if (typeof hsoRec.additionalContext === "string") out.additionalContext = hsoRec.additionalContext;
+    if (hsoRec.decision === "allow" || hsoRec.decision === "deny" || hsoRec.decision === "ask") {
+      out.permissionDecision = hsoRec.decision;
+    }
+    if (typeof hsoRec.reason === "string" && !out.reason) out.reason = hsoRec.reason;
+  }
+  return out;
+}
+
+export type HookOutcome = {
+  allowed: boolean;
+  additionalContext?: string;
+  permissionDecision?: "allow" | "deny" | "ask";
+  reason?: string;
+};
+
+/** Events for which "notify-only" semantics apply — outcome.allowed is always true. */
+const NOTIFY_ONLY_OUTCOME_EVENTS: ReadonlySet<HookEvent> = new Set<HookEvent>(["postToolUseFailure"]);
+
+/**
+ * Execute a single hook definition and return a ParsedJsonIoResponse for outcome merging.
+ * Private to this module — not exported.
+ */
+async function runHookForOutcome(def: HookDef, event: HookEvent, ctx: HookContext): Promise<ParsedJsonIoResponse> {
+  if (def.jsonIO && def.command) {
+    const env = buildEnv(event, ctx);
+    let raw: string;
+    try {
+      raw = await runJsonIoHookCaptureStdout(def.command, env, event, ctx, def.timeout ?? 10_000);
+    } catch {
+      // timeout, spawn error, non-zero exit — treat as deny for gating events
+      return { decision: "deny", reason: "hook failed (timeout or non-zero exit)" };
+    }
+    if (!raw.trim()) {
+      // empty stdout with exit 0 — treat as allow (no decision)
+      return {};
+    }
+    return parseJsonIoResponse(raw);
+  }
+
+  if (def.command) {
+    // env-var mode — gate on exit code
+    const env = buildEnv(event, ctx);
+    const code = await runCommandHookAsync(def.command, env, def.timeout ?? 10_000);
+    return code === 0 ? {} : { decision: "deny", reason: "hook denied (non-zero exit)" };
+  }
+
+  if (def.http) {
+    const allowed = await runHttpHook(def.http, event, ctx, def.timeout ?? 10_000);
+    return allowed ? {} : { decision: "deny", reason: "http hook denied" };
+  }
+
+  if (def.prompt) {
+    const allowed = await runPromptHook(def.prompt, ctx, def.timeout ?? 10_000);
+    return allowed ? {} : { decision: "deny", reason: "prompt hook denied" };
+  }
+
+  return {};
+}
+
+/**
+ * Emit a hook event and return a structured HookOutcome parsed from jsonIO responses.
+ *
+ * Merge semantics:
+ * - First `deny` (or `permissionDecision: "deny"`) short-circuits: {allowed: false, ...}.
+ * - `permissionDecision: "allow"` short-circuits: {allowed: true, permissionDecision: "allow"}.
+ * - `additionalContext` from multiple hooks is concatenated in order, "\n\n" separated.
+ * - For NOTIFY_ONLY_OUTCOME_EVENTS (postToolUseFailure), decision/permissionDecision
+ *   from hooks is ignored — outcome.allowed is always true. additionalContext is still collected.
+ */
+export async function emitHookWithOutcome(event: HookEvent, ctx: HookContext = {}): Promise<HookOutcome> {
+  const hooks = getHooks();
+  const list = hooks?.[event];
+  if (!list || list.length === 0) return { allowed: true };
+  const notifyOnly = NOTIFY_ONLY_OUTCOME_EVENTS.has(event);
+
+  const additionalContexts: string[] = [];
+  let reason: string | undefined;
+  let askSeen = false;
+
+  for (const def of list) {
+    if (def.match && !matchesHook(def, ctx)) continue;
+    const parsed = await runHookForOutcome(def, event, ctx);
+
+    if (!notifyOnly) {
+      if (parsed.decision === "deny" || parsed.permissionDecision === "deny") {
+        return {
+          allowed: false,
+          reason: parsed.reason ?? reason,
+          permissionDecision: parsed.permissionDecision,
+        };
+      }
+      if (parsed.permissionDecision === "allow") {
+        if (parsed.additionalContext) additionalContexts.push(parsed.additionalContext);
+        return {
+          allowed: true,
+          permissionDecision: "allow",
+          additionalContext: additionalContexts.length ? additionalContexts.join("\n\n") : undefined,
+        };
+      }
+      if (parsed.permissionDecision === "ask") askSeen = true;
+    }
+    if (parsed.additionalContext) additionalContexts.push(parsed.additionalContext);
+    if (!reason && parsed.reason) reason = parsed.reason;
+  }
+
+  return {
+    allowed: true,
+    additionalContext: additionalContexts.length ? additionalContexts.join("\n\n") : undefined,
+    permissionDecision: askSeen ? "ask" : undefined,
+    reason,
+  };
 }

--- a/src/harness/submit-handler.test.ts
+++ b/src/harness/submit-handler.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { describe, it } from "node:test";
+import { makeTmpDir } from "../test-helpers.js";
+import { invalidateConfigCache } from "./config.js";
 import { CostTracker } from "./cost.js";
+import { invalidateHookCache } from "./hooks.js";
 import { handleUserInput, type SubmitContext } from "./submit-handler.js";
 
 function makeCtx(overrides?: Partial<SubmitContext>): SubmitContext {
@@ -63,5 +67,83 @@ describe("handleUserInput", () => {
     assert.strictEqual(result.handled, true);
     const lastMsg = result.messages[result.messages.length - 1]!;
     assert.ok(lastMsg.content.includes("Unknown command"));
+  });
+});
+
+// ── userPromptSubmit hook integration tests ──
+
+async function withHookedCwd<T>(event: "userPromptSubmit", hookBodyJs: string, fn: () => Promise<T>): Promise<T> {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    const scriptPath = `${dir}/hook.cjs`;
+    writeFileSync(scriptPath, hookBodyJs);
+    mkdirSync(`${dir}/.oh`, { recursive: true });
+    writeFileSync(
+      `${dir}/.oh/config.yaml`,
+      [
+        "provider: mock",
+        "model: mock",
+        "permissionMode: ask",
+        "hooks:",
+        `  ${event}:`,
+        `    - command: "node ${scriptPath.replace(/\\/g, "/")}"`,
+        "      jsonIO: true",
+        "",
+      ].join("\n"),
+    );
+    invalidateConfigCache();
+    invalidateHookCache();
+    return await fn();
+  } finally {
+    process.chdir(original);
+    invalidateConfigCache();
+    invalidateHookCache();
+  }
+}
+
+describe("userPromptSubmit hook integration", () => {
+  it("prepends additionalContext to the returned prompt", async () => {
+    const hookBody =
+      "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({hookSpecificOutput:{additionalContext:'[CTX]'}})); });";
+    await withHookedCwd("userPromptSubmit", hookBody, async () => {
+      const ctx = makeCtx();
+      const res = await handleUserInput("hello", ctx);
+      assert.strictEqual(res.handled, false);
+      assert.strictEqual(res.prompt, "[CTX]\n\nhello");
+    });
+  });
+
+  it("blocks the prompt with deny decision", async () => {
+    const hookBody =
+      "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ process.stdout.write(JSON.stringify({decision:'deny',reason:'blocked'})); });";
+    await withHookedCwd("userPromptSubmit", hookBody, async () => {
+      const ctx = makeCtx();
+      const res = await handleUserInput("try me", ctx);
+      assert.strictEqual(res.handled, true);
+      assert.strictEqual(res.prompt, undefined);
+      // Check that an info message mentioning "blocked" was added
+      const infoText = (res.messages ?? []).map((m) => JSON.stringify(m)).join("|");
+      assert.match(infoText, /blocked/i);
+    });
+  });
+
+  it("no hook configured → prompt unchanged", async () => {
+    const dir = makeTmpDir();
+    const original = process.cwd();
+    process.chdir(dir);
+    try {
+      invalidateConfigCache();
+      invalidateHookCache();
+      const ctx = makeCtx();
+      const res = await handleUserInput("plain prompt", ctx);
+      assert.strictEqual(res.handled, false);
+      assert.strictEqual(res.prompt, "plain prompt");
+    } finally {
+      process.chdir(original);
+      invalidateConfigCache();
+      invalidateHookCache();
+    }
   });
 });

--- a/src/harness/submit-handler.ts
+++ b/src/harness/submit-handler.ts
@@ -11,6 +11,7 @@ import type { Message } from "../types/message.js";
 import { createInfoMessage, createUserMessage } from "../types/message.js";
 import type { PermissionMode } from "../types/permissions.js";
 import type { CostTracker } from "./cost.js";
+import { emitHookWithOutcome } from "./hooks.js";
 
 export type SubmitContext = {
   messages: Message[];
@@ -110,10 +111,28 @@ export async function handleUserInput(input: string, ctx: SubmitContext): Promis
       }
       if (result.prependToPrompt) {
         messages = [...messages, createUserMessage(input)];
+        const prependPrompt = result.prependToPrompt;
+        const prependOutcome = await emitHookWithOutcome("userPromptSubmit", {
+          prompt: prependPrompt,
+          sessionId: ctx.sessionId,
+          model: ctx.currentModel,
+          provider: ctx.providerName,
+          permissionMode: ctx.permissionMode,
+        });
+        if (!prependOutcome.allowed) {
+          const reason = prependOutcome.reason ? `: ${prependOutcome.reason}` : "";
+          return {
+            handled: true,
+            messages: [...messages, createInfoMessage(`Blocked by userPromptSubmit hook${reason}`)],
+          };
+        }
+        const finalPrependPrompt = prependOutcome.additionalContext
+          ? `${prependOutcome.additionalContext}\n\n${prependPrompt}`
+          : prependPrompt;
         return {
           handled: false,
           messages,
-          prompt: result.prependToPrompt,
+          prompt: finalPrependPrompt,
           newModel: result.newModel ?? undefined,
         };
       }
@@ -171,5 +190,20 @@ export async function handleUserInput(input: string, ctx: SubmitContext): Promis
     }
   }
 
-  return { handled: false, messages, prompt: resolvedInput };
+  const outcome = await emitHookWithOutcome("userPromptSubmit", {
+    prompt: resolvedInput,
+    sessionId: ctx.sessionId,
+    model: ctx.currentModel,
+    provider: ctx.providerName,
+    permissionMode: ctx.permissionMode,
+  });
+  if (!outcome.allowed) {
+    const reason = outcome.reason ? `: ${outcome.reason}` : "";
+    return {
+      handled: true,
+      messages: [...messages, createInfoMessage(`Blocked by userPromptSubmit hook${reason}`)],
+    };
+  }
+  const finalPrompt = outcome.additionalContext ? `${outcome.additionalContext}\n\n${resolvedInput}` : resolvedInput;
+  return { handled: false, messages, prompt: finalPrompt };
 }

--- a/src/mcp/config-normalize.test.ts
+++ b/src/mcp/config-normalize.test.ts
@@ -3,9 +3,12 @@ import { describe, it } from "node:test";
 import type { McpServerConfig } from "../harness/config.js";
 import { normalizeMcpConfig } from "./config-normalize.js";
 
-// Strings with ${VAR} syntax stored as constants to satisfy noTemplateCurlyInString lint rule.
+// Strings with ${VAR} syntax — intentional literal dollar-brace, not a template expression.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: intentional literal ${VAR} string for env-expansion tests
 const bearerLinear = "Bearer " + "${LINEAR_TOKEN}";
+// biome-ignore lint/suspicious/noTemplateCurlyInString: intentional literal ${VAR} string for env-expansion tests
 const bearerMissing = "Bearer " + "${MISSING_TOKEN}";
+// biome-ignore lint/suspicious/noTemplateCurlyInString: intentional literal ${VAR} string for env-expansion tests
 const literalNotExpanded = "literal-" + "${NOT_EXPANDED}";
 
 describe("normalizeMcpConfig", () => {

--- a/src/query/tools.test.ts
+++ b/src/query/tools.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for postToolUse / postToolUseFailure mutual exclusion in executeSingleTool.
+ *
+ * Strategy: invoke executeSingleTool directly with controlled mock tools, capturing
+ * hook emissions via the filesystem hook-script mechanism (same pattern as hooks.test.ts).
+ * Each test writes a tiny .oh/config.yaml that registers shell hooks for the events
+ * under test; hooks append the event name to a capture file. After execution we wait a
+ * short tick so the fire-and-forget hooks flush, then read the capture file.
+ *
+ * We cannot easily monkey-patch ESM exports, so the filesystem approach is the most
+ * reliable way to observe which hook events fired.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { z } from "zod";
+import { invalidateConfigCache } from "../harness/config.js";
+import { invalidateHookCache } from "../harness/hooks.js";
+import type { Tool, ToolContext, ToolResult } from "../Tool.js";
+import { makeTmpDir } from "../test-helpers.js";
+import { executeSingleTool } from "./tools.js";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/** Minimal ToolContext for tests — no git, no streaming output. */
+function makeContext(): ToolContext {
+  return {
+    workingDir: process.cwd(),
+    gitCommitPerTool: false,
+  };
+}
+
+/** Build a minimal mock Tool whose call() returns a fixed ToolResult. */
+function makeTool(name: string, result: ToolResult): Tool {
+  return {
+    name,
+    description: "test tool",
+    inputSchema: z.object({ input: z.string().optional() }),
+    riskLevel: "low",
+    isReadOnly() {
+      return true;
+    },
+    isConcurrencySafe() {
+      return true;
+    },
+    async call(): Promise<ToolResult> {
+      return result;
+    },
+    prompt() {
+      return name;
+    },
+  };
+}
+
+/** Build a mock Tool whose call() throws. */
+function makeThrowingTool(name: string, message: string): Tool {
+  return {
+    name,
+    description: "throwing test tool",
+    inputSchema: z.object({ input: z.string().optional() }),
+    riskLevel: "low",
+    isReadOnly() {
+      return true;
+    },
+    isConcurrencySafe() {
+      return true;
+    },
+    async call(): Promise<ToolResult> {
+      throw new Error(message);
+    },
+    prompt() {
+      return name;
+    },
+  };
+}
+
+/**
+ * Write an .oh/config.yaml in `dir` that registers hook commands for the given
+ * events. Each command appends "<eventName>\n" to the capture file at capturePath.
+ * We write a small .cjs helper script that appends the event name to avoid
+ * complex quoting in the YAML/shell command string.
+ */
+function writeHookConfig(dir: string, capturePath: string, events: Array<"postToolUse" | "postToolUseFailure">): void {
+  mkdirSync(`${dir}/.oh`, { recursive: true });
+
+  const lines = ["provider: mock", "model: mock", "permissionMode: trust", "hooks:"];
+  for (const e of events) {
+    // Write a dedicated .cjs capture script for this event to avoid shell quoting issues.
+    const scriptPath = `${dir}/capture-${e}.cjs`;
+    const capturePathFwd = capturePath.replace(/\\/g, "/");
+    writeFileSync(
+      scriptPath,
+      `require('node:fs').appendFileSync(${JSON.stringify(capturePathFwd)}, ${JSON.stringify(`${e}\n`)});`,
+    );
+    const scriptPathFwd = scriptPath.replace(/\\/g, "/");
+    lines.push(`  ${e}:`);
+    lines.push(`    - command: 'node ${scriptPathFwd}'`);
+  }
+  lines.push("");
+  writeFileSync(`${dir}/.oh/config.yaml`, lines.join("\n"));
+}
+
+/**
+ * Run `fn` inside a temporary cwd that has hooks configured for `events`.
+ * Returns the list of event names that fired (in order) and the tool result.
+ */
+async function withHookCapture<T>(
+  events: Array<"postToolUse" | "postToolUseFailure">,
+  fn: () => Promise<T>,
+): Promise<{ fired: string[]; result: T }> {
+  const dir = makeTmpDir();
+  const capturePath = `${dir}/captured.log`;
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    writeHookConfig(dir, capturePath, events);
+    invalidateConfigCache();
+    invalidateHookCache();
+
+    const result = await fn();
+
+    // Yield so fire-and-forget async hook processes can write to the capture file.
+    await new Promise<void>((r) => setTimeout(r, 150));
+
+    const fired = existsSync(capturePath) ? readFileSync(capturePath, "utf8").split("\n").filter(Boolean) : [];
+
+    return { fired, result };
+  } finally {
+    process.chdir(original);
+    invalidateHookCache();
+    invalidateConfigCache();
+  }
+}
+
+// ── ToolCall stub ────────────────────────────────────────────────────────────
+
+function makeToolCall(toolName: string, args: Record<string, unknown> = {}) {
+  return { toolName, arguments: args, id: "test-call-1" };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("tools.ts — postToolUse / postToolUseFailure mutual exclusion", () => {
+  it("successful tool (isError: false) fires postToolUse ONLY — not postToolUseFailure", async () => {
+    const tool = makeTool("SuccessTool", { output: "all good", isError: false });
+    const toolCall = makeToolCall("SuccessTool");
+
+    const { fired, result } = await withHookCapture(["postToolUse", "postToolUseFailure"], () =>
+      executeSingleTool(toolCall, [tool], makeContext(), "trust"),
+    );
+
+    assert.equal(result.isError, false, "tool result should be success");
+    assert.deepEqual(fired, ["postToolUse"], "only postToolUse should fire on success");
+  });
+
+  it("tool returning isError:true fires postToolUseFailure ONLY — not postToolUse", async () => {
+    const tool = makeTool("ErrorTool", { output: "bad input detected", isError: true });
+    const toolCall = makeToolCall("ErrorTool");
+
+    const { fired, result } = await withHookCapture(["postToolUse", "postToolUseFailure"], () =>
+      executeSingleTool(toolCall, [tool], makeContext(), "trust"),
+    );
+
+    assert.equal(result.isError, true, "tool result should be error");
+    assert.deepEqual(
+      fired,
+      ["postToolUseFailure"],
+      "only postToolUseFailure should fire when tool returns isError:true",
+    );
+  });
+
+  it("throwing tool fires postToolUseFailure ONLY — not postToolUse", async () => {
+    const tool = makeThrowingTool("ThrowingTool", "unexpected crash");
+    const toolCall = makeToolCall("ThrowingTool");
+
+    const { fired, result } = await withHookCapture(["postToolUse", "postToolUseFailure"], () =>
+      executeSingleTool(toolCall, [tool], makeContext(), "trust"),
+    );
+
+    assert.equal(result.isError, true, "throw should surface as isError:true");
+    assert.ok(result.output.includes("unexpected crash"), "error message should be in output");
+    assert.deepEqual(fired, ["postToolUseFailure"], "only postToolUseFailure should fire when tool throws");
+  });
+
+  it("hooks are independent — both fire when configured for both event paths", async () => {
+    // Run both a success and an error tool in sequence to confirm each fires
+    // the correct hook without cross-contamination.
+    const successTool = makeTool("SuccessA", { output: "ok", isError: false });
+    const errorTool = makeTool("ErrorB", { output: "fail", isError: true });
+
+    const dir = makeTmpDir();
+    const capturePath = `${dir}/captured.log`;
+    const original = process.cwd();
+    process.chdir(dir);
+    try {
+      writeHookConfig(dir, capturePath, ["postToolUse", "postToolUseFailure"]);
+      invalidateConfigCache();
+      invalidateHookCache();
+
+      await executeSingleTool(makeToolCall("SuccessA"), [successTool], makeContext(), "trust");
+      await executeSingleTool(makeToolCall("ErrorB"), [errorTool], makeContext(), "trust");
+
+      await new Promise<void>((r) => setTimeout(r, 200));
+
+      const fired = existsSync(capturePath) ? readFileSync(capturePath, "utf8").split("\n").filter(Boolean) : [];
+
+      // SuccessA → postToolUse, ErrorB → postToolUseFailure
+      assert.equal(fired.length, 2, "exactly two hook events should have fired");
+      assert.equal(fired[0], "postToolUse", "first event should be postToolUse (success)");
+      assert.equal(fired[1], "postToolUseFailure", "second event should be postToolUseFailure (error)");
+    } finally {
+      process.chdir(original);
+      invalidateHookCache();
+      invalidateConfigCache();
+    }
+  });
+});

--- a/src/query/tools.test.ts
+++ b/src/query/tools.test.ts
@@ -139,7 +139,186 @@ function makeToolCall(toolName: string, args: Record<string, unknown> = {}) {
   return { toolName, arguments: args, id: "test-call-1" };
 }
 
+// ── permissionRequest helpers ────────────────────────────────────────────────
+
+/**
+ * Build a mock Tool that triggers the needs-approval branch:
+ * - riskLevel "high" + isReadOnly() false so "ask" mode won't auto-approve.
+ * - call() returns the provided ToolResult.
+ */
+function makeNeedsApprovalTool(name: string, result: ToolResult): Tool {
+  return {
+    name,
+    description: "needs-approval test tool",
+    inputSchema: z.object({ input: z.string().optional() }),
+    riskLevel: "high",
+    isReadOnly() {
+      return false;
+    },
+    isConcurrencySafe() {
+      return false;
+    },
+    async call(): Promise<ToolResult> {
+      return result;
+    },
+    prompt() {
+      return name;
+    },
+  };
+}
+
+/**
+ * Write .oh/config.yaml in `dir` with:
+ * - permissionMode: ask  (so checkPermission returns needs-approval)
+ * - a permissionRequest hook that writes `hookJson` JSON to stdout, using jsonIO.
+ *
+ * When `hookJson` is null, no permissionRequest hook is configured.
+ */
+function writePermHookConfig(dir: string, hookJson: Record<string, unknown> | null): void {
+  mkdirSync(`${dir}/.oh`, { recursive: true });
+
+  const lines = ["provider: mock", "model: mock", "permissionMode: ask"];
+
+  if (hookJson !== null) {
+    // Write a .cjs hook script that prints the decision JSON to stdout then exits 0.
+    const scriptPath = `${dir}/perm-hook.cjs`;
+    const scriptPathFwd = scriptPath.replace(/\\/g, "/");
+    writeFileSync(scriptPath, `process.stdout.write(${JSON.stringify(JSON.stringify(hookJson))});\n`);
+    lines.push("hooks:");
+    lines.push("  permissionRequest:");
+    lines.push(`    - command: 'node ${scriptPathFwd}'`);
+    lines.push("      jsonIO: true");
+  }
+
+  lines.push("");
+  writeFileSync(`${dir}/.oh/config.yaml`, lines.join("\n"));
+}
+
+/**
+ * Run `fn` inside a temporary cwd configured for permissionRequest hook testing.
+ * Returns the tool result and the askUser invocation counter.
+ */
+async function withPermHook<T>(
+  hookJson: Record<string, unknown> | null,
+  fn: (askUserCounter: { count: number }) => Promise<T>,
+): Promise<{ result: T; askUserCount: number }> {
+  const dir = makeTmpDir();
+  const original = process.cwd();
+  process.chdir(dir);
+  try {
+    writePermHookConfig(dir, hookJson);
+    invalidateConfigCache();
+    invalidateHookCache();
+
+    const counter = { count: 0 };
+    const result = await fn(counter);
+
+    return { result, askUserCount: counter.count };
+  } finally {
+    process.chdir(original);
+    invalidateHookCache();
+    invalidateConfigCache();
+  }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("tools.ts — permissionRequest hook", () => {
+  it("hook 'allow' skips askUser and executes tool", async () => {
+    const tool = makeNeedsApprovalTool("ApprovalTool", { output: "executed", isError: false });
+    const toolCall = makeToolCall("ApprovalTool");
+
+    const { result, askUserCount } = await withPermHook({ hookSpecificOutput: { decision: "allow" } }, (counter) => {
+      const askUser = async () => {
+        counter.count++;
+        return true;
+      };
+      return executeSingleTool(toolCall, [tool], makeContext(), "ask", askUser);
+    });
+
+    assert.equal(askUserCount, 0, "askUser must NOT be called when hook says allow");
+    assert.equal(result.isError, false, "tool should have executed normally");
+    assert.ok(result.output.includes("executed"), "tool output should be returned");
+  });
+
+  it("hook 'deny' returns permission-denied without calling askUser", async () => {
+    const tool = makeNeedsApprovalTool("DenyTool", { output: "executed", isError: false });
+    const toolCall = makeToolCall("DenyTool");
+
+    const { result, askUserCount } = await withPermHook(
+      { hookSpecificOutput: { decision: "deny", reason: "no way" } },
+      (counter) => {
+        const askUser = async () => {
+          counter.count++;
+          return true;
+        };
+        return executeSingleTool(toolCall, [tool], makeContext(), "ask", askUser);
+      },
+    );
+
+    assert.equal(askUserCount, 0, "askUser must NOT be called when hook says deny");
+    assert.equal(result.isError, true, "result should be an error");
+    assert.ok(
+      /Permission denied.*no way/.test(result.output),
+      `output should mention denial reason, got: ${result.output}`,
+    );
+  });
+
+  it("hook 'ask' falls through to askUser", async () => {
+    const tool = makeNeedsApprovalTool("AskTool", { output: "executed", isError: false });
+    const toolCall = makeToolCall("AskTool");
+
+    const { result, askUserCount } = await withPermHook({ hookSpecificOutput: { decision: "ask" } }, (counter) => {
+      const askUser = async () => {
+        counter.count++;
+        return true; // user approves
+      };
+      return executeSingleTool(toolCall, [tool], makeContext(), "ask", askUser);
+    });
+
+    assert.equal(askUserCount, 1, "askUser MUST be called when hook says ask");
+    assert.equal(result.isError, false, "tool should execute after user approves");
+  });
+
+  it("no hook configured falls through to askUser", async () => {
+    const tool = makeNeedsApprovalTool("NoHookTool", { output: "executed", isError: false });
+    const toolCall = makeToolCall("NoHookTool");
+
+    const { result, askUserCount } = await withPermHook(
+      null, // no permissionRequest hook
+      (counter) => {
+        const askUser = async () => {
+          counter.count++;
+          return true;
+        };
+        return executeSingleTool(toolCall, [tool], makeContext(), "ask", askUser);
+      },
+    );
+
+    assert.equal(askUserCount, 1, "askUser MUST be called when no hook is configured");
+    assert.equal(result.isError, false, "tool should execute after user approves");
+  });
+
+  it("malformed hook response falls through to askUser (conservative)", async () => {
+    const tool = makeNeedsApprovalTool("MalformedTool", { output: "executed", isError: false });
+    const toolCall = makeToolCall("MalformedTool");
+
+    // Hook writes garbage — no valid permissionDecision can be parsed
+    const { result, askUserCount } = await withPermHook(
+      { someOtherField: "garbage", noDecisionHere: 42 },
+      (counter) => {
+        const askUser = async () => {
+          counter.count++;
+          return true;
+        };
+        return executeSingleTool(toolCall, [tool], makeContext(), "ask", askUser);
+      },
+    );
+
+    assert.equal(askUserCount, 1, "askUser MUST be called when hook response has no decision");
+    assert.equal(result.isError, false, "tool should execute after user approves");
+  });
+});
 
 describe("tools.ts — postToolUse / postToolUseFailure mutual exclusion", () => {
   it("successful tool (isError: false) fires postToolUse ONLY — not postToolUseFailure", async () => {

--- a/src/query/tools.ts
+++ b/src/query/tools.ts
@@ -103,12 +103,22 @@ export async function executeSingleTool(
       }),
     ]);
 
-    // Hook: postToolUse
-    emitHook("postToolUse", {
-      toolName: tool.name,
-      toolArgs: JSON.stringify(toolCall.arguments).slice(0, 1000),
-      toolOutput: result.output.slice(0, 1000),
-    });
+    // Hook: postToolUse / postToolUseFailure (mutually exclusive — strict CC parity)
+    if (result.isError) {
+      emitHook("postToolUseFailure", {
+        toolName: tool.name,
+        toolArgs: JSON.stringify(toolCall.arguments).slice(0, 1000),
+        toolOutput: result.output.slice(0, 1000),
+        toolError: "ReportedError",
+        errorMessage: result.output.slice(0, 1000),
+      });
+    } else {
+      emitHook("postToolUse", {
+        toolName: tool.name,
+        toolArgs: JSON.stringify(toolCall.arguments).slice(0, 1000),
+        toolOutput: result.output.slice(0, 1000),
+      });
+    }
 
     // Emit fileChanged hook for file-modifying tools
     if (!result.isError && ["Edit", "Write", "MultiEdit"].includes(tool.name)) {
@@ -167,7 +177,15 @@ export async function executeSingleTool(
     }
     return { output, isError: result.isError };
   } catch (err) {
-    return { output: `Tool error: ${err instanceof Error ? err.message : String(err)}`, isError: true };
+    const errMsg = err instanceof Error ? err.message : String(err);
+    const errName = err instanceof Error ? err.name : "ExecutionError";
+    emitHook("postToolUseFailure", {
+      toolName: tool.name,
+      toolArgs: JSON.stringify(toolCall.arguments).slice(0, 1000),
+      errorMessage: errMsg,
+      toolError: errName,
+    });
+    return { output: `Tool error: ${errMsg}`, isError: true };
   }
 }
 

--- a/src/query/tools.ts
+++ b/src/query/tools.ts
@@ -3,7 +3,7 @@
  */
 
 import { createCheckpoint, getAffectedFiles } from "../harness/checkpoints.js";
-import { emitHook } from "../harness/hooks.js";
+import { emitHook, emitHookWithOutcome } from "../harness/hooks.js";
 import type { ToolContext, ToolResult, Tools } from "../Tool.js";
 import { findToolByName } from "../Tool.js";
 import type { StreamEvent } from "../types/events.js";
@@ -64,9 +64,28 @@ export async function executeSingleTool(
     if (perm.reason === "needs-approval" && askUser) {
       const { formatToolArgs } = await import("../utils/tool-summary.js");
       const description = formatToolArgs(tool.name, toolCall.arguments as Record<string, unknown>);
-      const allowed = await askUser(tool.name, description, tool.riskLevel);
-      if (!allowed) {
-        return { output: "Permission denied by user.", isError: true };
+
+      // Hook: permissionRequest — fires between preToolUse and the interactive askUser prompt.
+      // Only fires when checkPermission says "needs-approval" AND askUser is provided.
+      const hookOutcome = await emitHookWithOutcome("permissionRequest", {
+        toolName: tool.name,
+        toolArgs: JSON.stringify(toolCall.arguments).slice(0, 1000),
+        toolInputJson: JSON.stringify(parsed.data).slice(0, 1000),
+        permissionMode,
+        permissionAction: "ask",
+      });
+
+      if (hookOutcome.permissionDecision === "allow") {
+        // Hook granted permission — skip interactive prompt and proceed to execution.
+      } else if (hookOutcome.permissionDecision === "deny" || !hookOutcome.allowed) {
+        const reason = hookOutcome.reason ? `: ${hookOutcome.reason}` : "";
+        return { output: `Permission denied by hook${reason}`, isError: true };
+      } else {
+        // "ask" or no decision → fall through to interactive prompt
+        const allowed = await askUser(tool.name, description, tool.riskLevel);
+        if (!allowed) {
+          return { output: "Permission denied by user.", isError: true };
+        }
       }
     } else {
       return { output: `Permission denied: ${perm.reason}`, isError: true };


### PR DESCRIPTION
Three hook events mirroring Claude Code semantics. First of three planned v2.13.0 features; version bump deferred. Details in CHANGELOG + docs/hooks.md. 1094 tests green (+41 new).